### PR TITLE
ma6 OCR corrections 00:01:00:00 - 00:03:00:00

### DIFF
--- a/missions/ma6/transcripts/TEC
+++ b/missions/ma6/transcripts/TEC
@@ -3295,7 +3295,7 @@ CC: Roger, Friendship Seven. Our fuel quantities here agree with yours. Our 150
 P: Roger, Friendship Seven.
 
 [00:02:46:14]
-CC: Friendship Seven, this is Canton. Do you have all the retro times that you need-d?
+CC: Friendship Seven, this is Canton. Do you have all the retro times that you need?
      Over.
 
 [00:02:46:19]


### PR DESCRIPTION
Corrected and verified OCR typos from the second and third hour of the Mercury 6 flight.
