### PR TITLE
Phase banners without images

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 import datetime
 import backend.util
 from urlparse import urlparse
@@ -335,6 +336,7 @@ class Act(NarrativeElement):
         super(Act, self)._load()
         self.description = self.data['description']
         self.banner = self.data.get("banner", None)
+        self.banner_background = self.data.get("banner_background", None)
         self.banner_class = self.data.get("banner_class", None)
         self.banner_colour = self.data.get("banner_colour", None)
         self.orbital = self.data.get("orbital", None)
@@ -348,10 +350,27 @@ class Act(NarrativeElement):
             self.stats_image_map_id = stats_data['image_map_id']
         else:
             self.has_stats = False
-    
+
     def key_scenes(self):
         return list( KeyScene.Query(self.redis_conn, self.mission_name).act_number(self.number).items() )
-    
+
+    def banner_styles(self):
+        """
+        Returns CSS to be applied to the act's banner, to apply styles defined
+        in the mission's _meta file.
+        """
+
+        styles = []
+        if self.banner_colour:
+            styles.append('background-color: %s' % self.banner_colour)
+        if self.banner_background:
+            styles.append('background-image: url(%s%s/images/banners/%s)' % (
+                settings.MISSIONS_STATIC_URL,
+                self.mission_name,
+                self.banner_background,
+            ))
+        return '; '.join(styles)
+
     class Query(NarrativeElement.Query):
         all_key_pattern = u"acts:%(mission_name)s"
 

--- a/chef/spacelog/recipes/default.rb
+++ b/chef/spacelog/recipes/default.rb
@@ -2,7 +2,7 @@ execute "apt-get update"
 
 %w{python python-setuptools python-pip redis-server python-redis
     python-virtualenv imagemagick subversion git-core python-xapian
-    ruby-sass}.each { |p|
+    ruby}.each { |p|
   package p
 }
 
@@ -19,4 +19,6 @@ execute "apt-get update"
   edit.write_file
 end
 
+execute "gem install watcher"
+execute "gem install sass"
 execute "pip install -r /vagrant/requirements.txt"

--- a/missions/a8/transcripts/_meta
+++ b/missions/a8/transcripts/_meta
@@ -69,7 +69,7 @@
             "title": "Launch",
             "description": "During takeoff the crew sat inside Odyssey, Apollo 13's Command Module, on top of the Saturn V rocket. As fuel was burnt up, the first two stages of the Saturn V were jettisoned and fell back to Earth along with the abort tower.",
             "range": ["-00:00:00:20", "07:00:00:00"],
-            "banner": "act1.jpg",
+            "banner_background": "act1.jpg",
             "banner_colour": "#5d86b2",
             "orbital": "act1.png",
             "illustration": "act1.gif",

--- a/website/static/css/screen/10-base.scss
+++ b/website/static/css/screen/10-base.scss
@@ -19,6 +19,10 @@ body {
     margin:                 0 auto;
 }
 
+#crest {
+    background-repeat:      no-repeat;
+    background-position:    center top;
+}
 #crest.blue {
     background:             #5d86b2;
 }

--- a/website/static/css/screen/transcripts-base.scss
+++ b/website/static/css/screen/transcripts-base.scss
@@ -341,8 +341,20 @@ p.load-more a {
 
 p.act-banner {
     height:                 200px;
-    margin:                 0 -34px 0 -41px;
-    overflow:               hidden;
+    line-height:            200px;
+    margin:                 0;
+    font-family:            'League Gothic',
+                            'Helvetica Neue Condensed',
+                            'Arial',
+                            sans-serif;
+    font-size:              70px;
+    text-transform:         uppercase;
+}
+p.act-banner img {
+    margin-left:            -41px;
+}
+p.act-banner b {
+    color:                  #f8b334;
 }
 
 /*! verbatim */

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -21,10 +21,16 @@
 {% block body-class %}transcript-section{% endblock %}
 
 {% block crest %}
-{% if log_lines.0.first_in_act and log_lines.0.act.banner %}
+{% if log_lines.0.first_in_act %}
   {% with log_lines.0.act as act %}
     <div id='crest' {% if act.banner_class %}class='{{ act.banner_class }}'{% endif %} {% if act.banner_colour %}style='background-color:{{ act.banner_colour }};'{% endif %}><div class='wrapper'>
-        <p class='act-banner'><img class="act-banner" src="{{ MISSIONS_STATIC_URL }}{{ act.mission_name }}/images/banners/{{ act.banner }}"></p>
+      <p class='act-banner'>
+        {% if act.banner %}
+          <img src="{{ MISSIONS_STATIC_URL }}{{ act.mission_name }}/images/banners/{{ act.banner }}" alt="Phase {{ act.number|add:1 }}: {{ act.title }}">
+        {% else %}
+          Phase {{ act.number|add:1 }}: <b>{{ act.title }}</b>
+        {% endif %}
+      </p>
     </div></div>
   {% endwith %}
   {% else %}<div id="crest"></div>{% endif %}

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -23,7 +23,7 @@
 {% block crest %}
 {% if log_lines.0.first_in_act %}
   {% with log_lines.0.act as act %}
-    <div id='crest' {% if act.banner_class %}class='{{ act.banner_class }}'{% endif %} {% if act.banner_colour %}style='background-color:{{ act.banner_colour }};'{% endif %}><div class='wrapper'>
+    <div id='crest' {% if act.banner_class %}class='{{ act.banner_class }}'{% endif %} {% if act.banner_styles %}style='{{ act.banner_styles }}'{% endif %}><div class='wrapper'>
       <p class='act-banner'>
         {% if act.banner %}
           <img src="{{ MISSIONS_STATIC_URL }}{{ act.mission_name }}/images/banners/{{ act.banner }}" alt="Phase {{ act.number|add:1 }}: {{ act.title }}">
@@ -33,7 +33,9 @@
       </p>
     </div></div>
   {% endwith %}
-  {% else %}<div id="crest"></div>{% endif %}
+{% else %}
+  <div id="crest"></div>
+{% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
* If there is a banner image, set appropriate `alt` text.
* If there isn't a banner image, display the title in the same style as the banner images that have already been produced.
* If there's a `banner_background`, set that as the `background-image` on the banner. This lets us make banner images that don't have text on them, cutting down on the complexity of setting up new missions.

This change paves the way for creating banner images that are just background images, and letting the browser render the text, which seems like a more sensible way of doing things.

These are the first CSS changes anyone's made since we switched to Sass, and I hadn't noticed that the `make devcss` and `make devcss_global` make targets weren't working on the default vagrant setup, so this PR fixes that too.