### PR TITLE
Upgrade from Django 1.4 to Django 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(global_screen_css): $(global_screen_sass) $(global_screen_sass_components)
 		$(global_screen_sass) > $(global_screen_css)
 
 devserver:
-	$(PYTHON) -m website.manage runconcurrentserver $(dev_webserver_ip):$(dev_webserver_port)
+	$(PYTHON) -m website.manage runserver $(dev_webserver_ip):$(dev_webserver_port)
 
 devcss:
 	sass --style compressed --watch $(website_screen_sass):$(website_screen_css)

--- a/global/configs/development/settings.py
+++ b/global/configs/development/settings.py
@@ -1,7 +1,6 @@
 from configs.settings import *
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 PROJECT_DOMAIN = "dev.spacelog.org:8000"
 
 try:

--- a/global/configs/live/global_wsgi.py
+++ b/global/configs/live/global_wsgi.py
@@ -20,5 +20,5 @@ sys.path[:0] = new_sys_path
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "global.configs.live.settings"
  
-from django.core.handlers.wsgi import WSGIHandler
-application = WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()

--- a/global/configs/live/settings.py
+++ b/global/configs/live/settings.py
@@ -1,4 +1,9 @@
 from configs.settings import *
+
+ALLOWED_HOSTS = [
+    '.spacelog.org.',
+]
+
 # The following MUST be an absolute URL in live deploys (it's given out
 # to other systems). Also, it doesn't get overridden in local_settings.py
 # unlike the others.

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -20,16 +20,7 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'test.db',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
-    }
-}
+DATABASES = {}
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -12,7 +12,6 @@ SITE_ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(os.path.join(SITE_ROOT, 'apps'))
 
 DEBUG = False
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -70,33 +69,30 @@ ADMIN_MEDIA_PREFIX = '/media/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'hqp*)4r*a99h4@=7@5bpdn+ik8+x9c&=zk4o-=w1ap6n!9_@z1'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(SITE_ROOT, 'templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'homepage.context.static',
+            ],
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'homepage.middleware.HoldingMiddleware',
 )
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "homepage.context.static",
-)
-
 ROOT_URLCONF = 'urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(SITE_ROOT, 'templates'),
-)
 
 INSTALLED_APPS = (
     'homepage',

--- a/global/configs/staging/global.wsgi
+++ b/global/configs/staging/global.wsgi
@@ -20,5 +20,5 @@ sys.path[:0] = new_sys_path
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "global.configs.staging.settings"
  
-from django.core.handlers.wsgi import WSGIHandler
-application = WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()

--- a/global/manage.py
+++ b/global/manage.py
@@ -10,12 +10,8 @@ project_path = os.path.realpath(os.path.dirname(__file__))
 sys.path.insert(0, project_path)
 sys.path.insert(0, os.path.join(project_path, '../'))
 
-import ext
-
-from django.core.management import execute_manager
-args = sys.argv
 # Let's figure out our environment
-if os.environ.has_key('DJANGOENV'):
+if 'DJANGOENV' in os.environ:
     environment = os.environ['DJANGOENV']
 elif len(sys.argv) > 1:
     # this doesn't currently work
@@ -26,20 +22,21 @@ elif len(sys.argv) > 1:
         environment = None
 else:
     environment = None
+
 try:
     module = "configs.%s.settings" % environment
     __import__(module)
-    settings = sys.modules[module]
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", module)
     # worked, so add it into the path so we can import other things out of it
     sys.path.insert(0, os.path.join(project_path, 'configs', environment))
 except ImportError:
     environment = None
 
 # We haven't found anything helpful yet, so use development.
-if environment == None:
+if environment is None:
     try:
         import configs.development.settings
-        settings = configs.development.settings
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))
     except ImportError:
@@ -47,4 +44,5 @@ if environment == None:
         sys.exit(1)
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/global/urls.py
+++ b/global/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import url, patterns
 from django.conf import settings
 #from search.views import SearchView
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-django~=1.4.0
+django~=1.5.0
 redis
 boto
 django-templatetag-sugar==0.1
-django_concurrent_test_server
 gunicorn==19.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django~=1.7.0
+django~=1.8.0
 redis~=2.2.0
 boto
 django-templatetag-sugar==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django~=1.6.0
+django~=1.7.0
 redis~=2.2.0
 boto
 django-templatetag-sugar==0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django~=1.5.0
-redis
+django~=1.6.0
+redis~=2.2.0
 boto
 django-templatetag-sugar==0.1
 gunicorn==19.3.0

--- a/website/apps/common/response.py
+++ b/website/apps/common/response.py
@@ -1,6 +1,6 @@
+import json
 from django.template.loader_tags import BlockNode
 from django.template.response import TemplateResponse
-from django.utils import simplejson
 
 
 class JsonTemplateResponse(TemplateResponse):
@@ -12,4 +12,4 @@ class JsonTemplateResponse(TemplateResponse):
         output = {}
         for n in template.nodelist.get_nodes_by_type(BlockNode):
             output[n.name] = n.render(context)
-        return simplejson.dumps(output)
+        return json.dumps(output)

--- a/website/apps/common/response.py
+++ b/website/apps/common/response.py
@@ -1,15 +1,16 @@
 import json
 from django.template.loader_tags import BlockNode
 from django.template.response import TemplateResponse
+from django.template.context import make_context
 
 
 class JsonTemplateResponse(TemplateResponse):
     @property
     def rendered_content(self):
-        template = self.resolve_template(self.template_name)
-        context = self.resolve_context(self.context_data)
-
+        template = self.resolve_template(self.template_name).template
+        context = make_context(self.context_data, self._request)
         output = {}
-        for n in template.nodelist.get_nodes_by_type(BlockNode):
-            output[n.name] = n.render(context)
+        with context.bind_template(template):
+            for n in template.nodelist.get_nodes_by_type(BlockNode):
+                output[n.name] = n.render(context)
         return json.dumps(output)

--- a/website/apps/common/views.py
+++ b/website/apps/common/views.py
@@ -1,6 +1,6 @@
+import json
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
-from django.utils import simplejson
 from django.views.generic import TemplateView
 from website.apps.common.response import JsonTemplateResponse
 
@@ -13,8 +13,8 @@ class JsonTemplateView(TemplateView):
             return super(JsonTemplateView, self).render_to_response(context, **response_kwargs)
 
     def render_to_json_response(self, context, **response_kwargs):
-        if 'mimetype' not in response_kwargs:
-            response_kwargs['mimetype'] = 'application/json'
+        if 'content_type' not in response_kwargs:
+            response_kwargs['content_type'] = 'application/json'
         return JsonTemplateResponse(
             request=self.request,
             template=self.get_template_names(),
@@ -26,6 +26,6 @@ class JsonTemplateView(TemplateView):
 class JsonMixin(object):
     def render_to_response(self, context=None):
         return HttpResponse(
-            content=simplejson.dumps(context),
-            mimetype='application/json',
+            content=json.dumps(context),
+            content_type='application/json',
         )

--- a/website/configs/development/settings.py
+++ b/website/configs/development/settings.py
@@ -1,7 +1,6 @@
 from configs.settings import *
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 PROJECT_HOME = "http://dev.spacelog.org:8001/"
 
 try:

--- a/website/configs/development/settings.py
+++ b/website/configs/development/settings.py
@@ -4,8 +4,6 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 PROJECT_HOME = "http://dev.spacelog.org:8001/"
 
-INSTALLED_APPS += ('django_concurrent_test_server',)
-
 try:
     from local_settings import *
 except ImportError:

--- a/website/configs/live/settings.py
+++ b/website/configs/live/settings.py
@@ -1,4 +1,9 @@
 from configs.settings import *
+
+ALLOWED_HOSTS = [
+    '.spacelog.org.',
+]
+
 # The following MUST be an absolute URL in live deploys (it's given out
 # to other systems). Also, it doesn't get overridden in local_settings.py
 # unlike the others.

--- a/website/configs/live/website_wsgi.py
+++ b/website/configs/live/website_wsgi.py
@@ -20,5 +20,5 @@ sys.path[:0] = new_sys_path
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "website.configs.live.settings"
  
-from django.core.handlers.wsgi import WSGIHandler
-application = WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -12,7 +12,6 @@ SITE_ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(os.path.join(SITE_ROOT, 'apps'))
 
 DEBUG = False
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -75,12 +74,25 @@ ADMIN_MEDIA_PREFIX = '/media/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'hqp*)4r*a99h4@=7@5bpdn+ik8+x9c&=zk4o-=w1ap6n!9_@z1'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(SITE_ROOT, 'templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.core.context_processors.debug',
+                'django.core.context_processors.i18n',
+                'django.core.context_processors.media',
+                'django.core.context_processors.request',
+                'transcripts.context.mission',
+                'transcripts.context.static',
+            ],
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -88,23 +100,7 @@ MIDDLEWARE_CLASSES = (
     'transcripts.middleware.MissionMiddleware',
 )
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.request",
-    "transcripts.context.mission",
-    "transcripts.context.static",
-)
-
 ROOT_URLCONF = 'urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    os.path.join(SITE_ROOT, 'templates'),
-)
 
 INSTALLED_APPS = (
     'django.contrib.humanize',

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -20,16 +20,7 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'test.db',                      # Or path to database file if using sqlite3.
-        'USER': '',                      # Not used with sqlite3.
-        'PASSWORD': '',                  # Not used with sqlite3.
-        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
-    }
-}
+DATABASES = {}
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/website/configs/staging/website.wsgi
+++ b/website/configs/staging/website.wsgi
@@ -20,5 +20,5 @@ sys.path[:0] = new_sys_path
 
 os.environ["DJANGO_SETTINGS_MODULE"] = "website.configs.staging.settings"
  
-from django.core.handlers.wsgi import WSGIHandler
-application = WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()

--- a/website/manage.py
+++ b/website/manage.py
@@ -10,12 +10,8 @@ project_path = os.path.realpath(os.path.dirname(__file__))
 sys.path.insert(0, project_path)
 sys.path.insert(0, os.path.join(project_path, '../'))
 
-import ext
-
-from django.core.management import execute_manager
-args = sys.argv
 # Let's figure out our environment
-if os.environ.has_key('DJANGOENV'):
+if 'DJANGOENV' in os.environ:
     environment = os.environ['DJANGOENV']
 elif len(sys.argv) > 1:
     # this doesn't currently work
@@ -26,20 +22,21 @@ elif len(sys.argv) > 1:
         environment = None
 else:
     environment = None
+
 try:
     module = "configs.%s.settings" % environment
     __import__(module)
-    settings = sys.modules[module]
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", module)
     # worked, so add it into the path so we can import other things out of it
     sys.path.insert(0, os.path.join(project_path, 'configs', environment))
 except ImportError:
     environment = None
 
 # We haven't found anything helpful yet, so use development.
-if environment == None:
+if environment is None:
     try:
         import configs.development.settings
-        settings = configs.development.settings
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))
     except ImportError:
@@ -47,4 +44,5 @@ if environment == None:
         sys.exit(1)
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/website/templates/_base/masthead.html
+++ b/website/templates/_base/masthead.html
@@ -5,11 +5,11 @@
     <h1><a href='{{ PROJECT_HOME }}'>Spacelog</a> <a href="/" class="mission">{{ mission.title }}</a></h1>
     <nav>
       <ul>
-        <li class='transcript-section'><a href='{% url view_page %}'>Transcripts</a></li>
-        <li class='phase-section'><a href='{% url phases %}'>Phases</a></li>
-        <li class='people-section'><a href='{% url people %}'>People</a></li>
-        <li class='glossary-section'><a href='{% url glossary %}'>Glossary</a></li>
-        <li class='about-section'><a href='{% url about %}'>About</a></li>
+        <li class='transcript-section'><a href='{% url "view_page" %}'>Transcripts</a></li>
+        <li class='phase-section'><a href='{% url "phases" %}'>Phases</a></li>
+        <li class='people-section'><a href='{% url "people" %}'>People</a></li>
+        <li class='glossary-section'><a href='{% url "glossary" %}'>Glossary</a></li>
+        <li class='about-section'><a href='{% url "about" %}'>About</a></li>
       </ul>
       <form method="get" action="/search/">
         <input type="text" name="q" value="{{ q|escape }}" id="q"

--- a/website/templates/error.html
+++ b/website/templates/error.html
@@ -17,11 +17,11 @@
 <p>{{ text|safe }}</p>
 
 <p>
-    Why not browse the <a href='{% url view_page %}'>transcripts</a>?
+    Why not browse the <a href='{% url "view_page" %}'>transcripts</a>?
     {% if classic_moment %}
     Check out the classic <a href='{% selection_url classic_moment_quote %}'>{{ classic_moment }}</a> moment, or
     {% else %}
     Or,
     {% endif %}
-    go back to the <a href='{% url homepage %}'>home page.</a></p>
+    go back to the <a href='{% url "homepage" %}'>home page.</a></p>
 {% endblock %}

--- a/website/templates/homepage/_quote.html
+++ b/website/templates/homepage/_quote.html
@@ -8,7 +8,7 @@
   <i>
   <cite><a class='transcript' href="{% selection_url_in_transcript quote.timestamp quote.transcript_name %}">Read this moment</a></cite>
   <span> or </span>
-  <a class='refresh' href='{% url homepage %}'>See another</a>
+  <a class='refresh' href='{% url "homepage" %}'>See another</a>
   </i>
 </div>
 {% endif %}

--- a/website/templates/homepage/about.html
+++ b/website/templates/homepage/about.html
@@ -11,7 +11,7 @@
     {% if mission.copy.about_image %}
     <img src='{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/{{ mission.copy.about_image }}' width='270' alt=''>
     {% else %}
-    <a href='{% url original 1 %}'>
+    <a href='{% url "original" 1 %}'>
         <img src='{{ MISSIONS_IMAGE_URL }}{{ mission.name }}/images/original/TEC/about.png'
            width='270' alt=''>
       View this page in the original transcript

--- a/website/templates/homepage/homepage.html
+++ b/website/templates/homepage/homepage.html
@@ -19,7 +19,7 @@
 {% for number, act in acts %}
   <li>
     {% ifequal 1 number %}
-    <a href='{% url view_page %}'>
+    <a href='{% url "view_page" %}'>
     {% else %}
     <a href='{% timestamp_to_url act.start %}'>
     {% endifequal %}

--- a/website/templates/people/people.html
+++ b/website/templates/people/people.html
@@ -23,7 +23,7 @@
 
 {% if more_people %}
 <div class="more">
-  <a href="{% url people "mission-ops" %}">View Mission Control Team</a>
+  <a href="{% url "people" "mission-ops" %}">View Mission Control Team</a>
 </div>
 {% endif %}
 

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -10,7 +10,7 @@
 {% if log_lines.0.previous %}
 <link rel="canonical" href="{% timestamp_to_url log_lines.0.timestamp %}">
 {% else %}
-<link rel="canonical" href="{% url view_page %}">
+<link rel="canonical" href="{% url "view_page" %}">
 {% endif %}
 {% endif %}{% endblock %}
 
@@ -158,7 +158,7 @@
         {% else %}
           <li class='prev'><span>Previous</span></li>
         {% endif %}
-        <li><em><a href='{% url phases current_act.one_based_number %}'>Phase {{ act }}: {{ current_act.title }}</a></em></li>
+        <li><em><a href='{% url "phases" current_act.one_based_number %}'>Phase {{ act }}: {{ current_act.title }}</a></em></li>
         {% if next_act %}
           <li><a href='{% timestamp_to_url next_act.start %}' rel='next'><span>Next</span></a></li>
         {% else %}

--- a/website/templates/transcripts/phases.html
+++ b/website/templates/transcripts/phases.html
@@ -21,7 +21,7 @@
         {% if nav_act.number == act.number %}
           <li class='selected'><span>You are here: </span><strong>{{ nav_act.one_based_number|apnumber }}</strong></li>
         {% else %}
-          <li><a href='{% url phases nav_act.one_based_number %}' title='{{ nav_act.title }}'>{{ nav_act.one_based_number|apnumber }}</a></li>
+          <li><a href='{% url "phases" nav_act.one_based_number %}' title='{{ nav_act.title }}'>{{ nav_act.one_based_number|apnumber }}</a></li>
         {% endif %}
       {% endfor %}
     </ol>
@@ -30,7 +30,7 @@
   <div class='details'>
     <h1>{{ act.title }}</h1>
     {% ifequal act.number 0 %}
-    <a class='league-gothic read-button' href="{% url view_page %}">Start reading</a>
+    <a class='league-gothic read-button' href="{% url "view_page" %}">Start reading</a>
     {% else %}
     <a class='league-gothic read-button' href="{% timestamp_to_url act.start %}">Start reading</a>
     {% endifequal %}

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 from django.conf import settings
 from transcripts.views import PageView, PhasesView, RangeView, ErrorView, OriginalView
 from homepage.views import HomepageView, HomepageQuoteView


### PR DESCRIPTION
This yak shave is sponsored by #229, and specifically a desire to use the `ManifestStaticFilesStorage`.

Each major upgrade is covered by a single commit, and the commit messages include notes on what I needed to change to get things working. I tried to take into account:

* Things that broke after the upgrade,
* things that were mentioned in the release notes, and
* things that were mentioned in the deprecation schedule.

The things I was least sure of were:

* Removing `django_concurrent_test_server` for the upgrade to Django 1.5. Maybe I should have tired to fix it instead of just giving up on it.
* The changes to `JsonTemplateResponse` for the upgrade to Django 1.8. I felt like I was messing around with internals too much.