### PR TITLE
Use django.contrib.staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /global/static/css/screen.css.map
 /website/local_settings.py
 /global/local_settings.py
+/website/collected
+/global/collected
 /missions/*/images/stats
 /missions/*/images/original
 /missions/*/images/media

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,13 @@ dev_webserver_ip         ?= 0.0.0.0
 dev_webserver_port       ?= 8000
 dev_global_port          ?= 8001
 
-all: reindex productioncss statsporn
+all: reindex collectstatic
 
 dirty: copyxapian productioncss copy_statsporn
+
+collectstatic: productioncss statsporn
+	$(PYTHON) -m website.manage collectstatic --noinput --ignore=*.scss
+	$(PYTHON) -m global.manage collectstatic --noinput --ignore=*.scss
 
 reindex: $(indexer)
 	rm -rf xappydb

--- a/backend/api.py
+++ b/backend/api.py
@@ -373,11 +373,13 @@ class Act(NarrativeElement):
         if self.banner_colour:
             styles.append('background-color: %s' % self.banner_colour)
         if self.banner_background:
-            styles.append('background-image: url(%s%s/images/banners/%s)' % (
-                settings.MISSIONS_STATIC_URL,
+            from apps.transcripts.templatetags.missionstatic import mission_static
+            url = mission_static(
                 self.mission_name,
+                'images/banners',
                 self.banner_background,
-            ))
+            )
+            styles.append('background-image: url(%s)' % url)
         return '; '.join(styles)
 
     class Query(NarrativeElement.Query):

--- a/backend/api.py
+++ b/backend/api.py
@@ -356,6 +356,7 @@ class Act(NarrativeElement):
             self.has_stats = True
             self.stats_image_map = stats_data['image_map']
             self.stats_image_map_id = stats_data['image_map_id']
+            self.stats_image = "graph_%s_%d.png" % (self.mission_name, self.number)
         else:
             self.has_stats = False
 

--- a/global/apps/homepage/context.py
+++ b/global/apps/homepage/context.py
@@ -1,6 +1,0 @@
-from django.conf import settings
-
-def static(request):
-    return {
-        "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
-    }

--- a/global/apps/homepage/context.py
+++ b/global/apps/homepage/context.py
@@ -3,6 +3,5 @@ from django.conf import settings
 def static(request):
     return {
         "STATIC_URL": settings.STATIC_URL,
-        "FIXED_STATIC_URL": settings.FIXED_STATIC_URL,
         "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
     }

--- a/global/apps/homepage/context.py
+++ b/global/apps/homepage/context.py
@@ -2,6 +2,5 @@ from django.conf import settings
 
 def static(request):
     return {
-        "STATIC_URL": settings.STATIC_URL,
         "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
     }

--- a/global/configs/live/settings.py
+++ b/global/configs/live/settings.py
@@ -5,11 +5,9 @@ ALLOWED_HOSTS = [
 ]
 
 # The following MUST be an absolute URL in live deploys (it's given out
-# to other systems). Also, it doesn't get overridden in local_settings.py
-# unlike the others.
-FIXED_STATIC_URL = 'http://cdn.spacelog.org/assets/global/'
-
+# to other systems).
 STATIC_URL = 'http://cdn.spacelog.org/assets/global/'
+
 # I believe the next line to be true, although /assets/global/missions/ works too;
 # this feels more correct.
 MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'

--- a/global/configs/live/settings.py
+++ b/global/configs/live/settings.py
@@ -8,10 +8,6 @@ ALLOWED_HOSTS = [
 # to other systems).
 STATIC_URL = 'http://cdn.spacelog.org/assets/global/'
 
-# I believe the next line to be true, although /assets/global/missions/ works too;
-# this feels more correct.
-MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'
-
 # allow local overrides, probably built during deploy
 try:
     from local_settings import *

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -53,10 +53,20 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
-STATIC_ROOT = os.path.join(SITE_ROOT, 'static')
-STATIC_URL  = '/assets/'
-MISSIONS_STATIC_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
-MISSIONS_STATIC_URL = '/assets/missions/'
+STATICFILES_DIRS = [
+    os.path.join(SITE_ROOT, 'static'),
+]
+
+MISSIONS_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
+for mission_name in os.listdir(MISSIONS_ROOT):
+    mission_image_path = os.path.join(MISSIONS_ROOT, mission_name, 'images')
+    if os.path.isdir(mission_image_path):
+        STATICFILES_DIRS += [
+            ("missions/%s/images" % mission_name, mission_image_path),
+        ]
+
+STATIC_ROOT = os.path.join(SITE_ROOT, 'collected')
+STATIC_URL = '/assets/'
 
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.
@@ -91,9 +101,10 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'urls'
 
 INSTALLED_APPS = (
+    'django.contrib.staticfiles',
     'homepage',
     'search',
-    'website.apps.transcripts'
+    'website.apps.transcripts',
 )
 
 PROJECT_DOMAIN = "spacelog.org"

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -78,7 +78,6 @@ TEMPLATES = [
                 'django.core.context_processors.debug',
                 'django.core.context_processors.i18n',
                 'django.core.context_processors.media',
-                'homepage.context.static',
             ],
         },
     },

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -54,6 +54,7 @@ MEDIA_ROOT = ''
 MEDIA_URL = ''
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -53,6 +53,7 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -55,9 +55,6 @@ MEDIA_URL = ''
 
 STATIC_ROOT = os.path.join(SITE_ROOT, 'static')
 STATIC_URL  = '/assets/'
-# FIXED_STATIC_URL doesn't change with varying deploys, so can be used for
-# things that need long-term URLs, like image references in the Open Graph.
-FIXED_STATIC_URL  = '/assets/'
 MISSIONS_STATIC_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
 MISSIONS_STATIC_URL = '/assets/missions/'
 

--- a/global/templates/base.html
+++ b/global/templates/base.html
@@ -17,8 +17,8 @@
   <meta property="og:title dc:title" content="Spacelog">
   <meta property="og:type" content="website">
   <meta property="og:url foaf:homepage" content="http://spacelog.org/">
-  <meta property="og:image" content="{{ FIXED_STATIC_URL }}img/dfv-badge.png">
-  <link property="foaf:depiction" href="{{ FIXED_STATIC_URL }}img/dfv-badge.png">
+  <meta property="og:image" content="{{ STATIC_URL }}img/dfv-badge.png">
+  <link property="foaf:depiction" href="{{ STATIC_URL }}img/dfv-badge.png">
   {# see comment in website/templates/base.html for explanation of repeated RDFa. #}
   <meta property="og:site_name" content="Spacelog">
   <!-- <meta property="og:description"

--- a/global/templates/base.html
+++ b/global/templates/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"
@@ -10,15 +10,15 @@
       lang="en-us">
 <head>
   <title>{% block title %}SET THE TITLE{% endblock %}</title>
-  <link rel="stylesheet" href="{{ STATIC_URL }}css/screen.css" media="screen">
-  <link rel="shortcut icon" href="{{ STATIC_URL}}img/favicon.ico">
+  <link rel="stylesheet" href="{% static "css/screen.css" %}" media="screen">
+  <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
   <meta name="description" content="Spacelog: a site for experiencing early space missions through radio transcripts and photography.">
   <meta name="keywords" content="spacelog,space,spaceflight,spacecraft,orbit,apollo,mercury,gemini,mission,moon,radio,transcript,photographs,photography">
   <meta property="og:title dc:title" content="Spacelog">
   <meta property="og:type" content="website">
   <meta property="og:url foaf:homepage" content="http://spacelog.org/">
-  <meta property="og:image" content="{{ STATIC_URL }}img/dfv-badge.png">
-  <link property="foaf:depiction" href="{{ STATIC_URL }}img/dfv-badge.png">
+  <meta property="og:image" content="{% static "img/dfv-badge.png" %}">
+  <link property="foaf:depiction" href="{% static "img/dfv-badge.png" %}">
   {# see comment in website/templates/base.html for explanation of repeated RDFa. #}
   <meta property="og:site_name" content="Spacelog">
   <!-- <meta property="og:description"

--- a/global/templates/base.html
+++ b/global/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+{% load staticfiles %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"

--- a/global/templates/base.html
+++ b/global/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load staticfiles %}{% load missionstatic %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"
@@ -17,8 +17,8 @@
   <meta property="og:title dc:title" content="Spacelog">
   <meta property="og:type" content="website">
   <meta property="og:url foaf:homepage" content="http://spacelog.org/">
-  <meta property="og:image" content="{% static "img/dfv-badge.png" %}">
-  <link property="foaf:depiction" href="{% static "img/dfv-badge.png" %}">
+  <meta property="og:image" content="{% digest_free_static "img/dfv-badge.png" %}">
+  <link property="foaf:depiction" href="{% digest_free_static "img/dfv-badge.png" %}">
   {# see comment in website/templates/base.html for explanation of repeated RDFa. #}
   <meta property="og:site_name" content="Spacelog">
   <!-- <meta property="og:description"

--- a/global/templates/holding.html
+++ b/global/templates/holding.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+{% load staticfiles %}<!DOCTYPE html>
 <html>
 <head>
   <title>We'll be back soon.</title>

--- a/global/templates/holding.html
+++ b/global/templates/holding.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html>
 <head>
   <title>We'll be back soon.</title>
-  <link rel="stylesheet" href="{{ STATIC_URL }}css/screen.css" media="screen">
+  <link rel="stylesheet" href="{% static "css/screen.css" %}" media="screen">
 </head>
 <body>
   <div id='content' class='not_found'><div class="wrapper">

--- a/global/templates/homepage/_feature.html
+++ b/global/templates/homepage/_feature.html
@@ -1,5 +1,6 @@
+{% load missionstatic %}
 {% load missions %}<h3>{% if not mission.incomplete %}<a href="{{ mission|mission_url }}">{% endif %}
-        <img src="{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/badge.png" alt=""
+        <img src="{% mission_static mission.name "images/badge.png" %}" alt=""
       width="200" height="200">
   <span>{{ mission.title }} ({{ mission.year }})</span>
 {% if not mission.incomplete %}</a>{% endif %}</h3>

--- a/global/templates/homepage/_mission.html
+++ b/global/templates/homepage/_mission.html
@@ -1,5 +1,6 @@
+{% load missionstatic %}
 {% load missions %}<h3><a href="{{ mission|mission_url }}">
-    <img src="{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/badge_thumb.png" alt=""
+    <img src="{% mission_static mission.name "images/badge_thumb.png" %}" alt=""
   width="40" height="40">
   <span>{{ mission.title }}
   ({{ mission.year }})</span>

--- a/global/templates/pages/get-involved.html
+++ b/global/templates/pages/get-involved.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}Getting Involved with Spacelog{% endblock %}
 
@@ -33,7 +34,7 @@
   {% comment %}
   Could use a figure, but that would involve the IE shim in order to style it properly
   {% endcomment %}
-  <img src='{{ STATIC_URL }}img/transcripts-pile.png' width='300' height='434'>
+  <img src='{% static "img/transcripts-pile.png" %}' width='300' height='434'>
   <p>
     Much of the content for Spacelog comes from original transcripts of audio recordings in the 1960s and 1970s. Our volunteers help convert and clean up these transcripts, or create new ones from the original audio.
   </p>

--- a/global/templates/pages/get-involved.html
+++ b/global/templates/pages/get-involved.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load staticfiles %}
 
 {% block title %}Getting Involved with Spacelog{% endblock %}
 

--- a/global/urls.py
+++ b/global/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import url, patterns
 from django.conf import settings
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 #from search.views import SearchView
 
 urlpatterns = patterns('',
@@ -10,16 +11,4 @@ urlpatterns = patterns('',
     # url(r'^search/$', SearchView.as_view(), name="search"),
 )
 
-if settings.DEBUG: # pragma: no cover
-    urlpatterns += patterns('',
-        (r'^' + settings.MISSIONS_STATIC_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.MISSIONS_STATIC_ROOT
-        }),
-        (r'^' + settings.STATIC_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.STATIC_ROOT
-        }),
-        # (r'^' + settings.MEDIA_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-        #     'document_root': settings.MEDIA_ROOT
-        # }),
-    )
-
+urlpatterns += staticfiles_urlpatterns()

--- a/website/apps/transcripts/context.py
+++ b/website/apps/transcripts/context.py
@@ -13,7 +13,6 @@ def mission(request):
 
 def static(request):
     return {
-        "STATIC_URL": settings.STATIC_URL,
         "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
         "MISSIONS_IMAGE_URL": settings.MISSIONS_IMAGE_URL,
     }

--- a/website/apps/transcripts/context.py
+++ b/website/apps/transcripts/context.py
@@ -13,6 +13,5 @@ def mission(request):
 
 def static(request):
     return {
-        "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
         "MISSIONS_IMAGE_URL": settings.MISSIONS_IMAGE_URL,
     }

--- a/website/apps/transcripts/context.py
+++ b/website/apps/transcripts/context.py
@@ -14,7 +14,6 @@ def mission(request):
 def static(request):
     return {
         "STATIC_URL": settings.STATIC_URL,
-        "FIXED_MISSIONS_STATIC_URL": settings.FIXED_MISSIONS_STATIC_URL,
         "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
         "MISSIONS_IMAGE_URL": settings.MISSIONS_IMAGE_URL,
     }

--- a/website/apps/transcripts/templatetags/characters.py
+++ b/website/apps/transcripts/templatetags/characters.py
@@ -1,8 +1,14 @@
 from django.template import Library
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from apps.transcripts.templatetags.missionstatic import mission_static
 
 register = Library()
+
+
+def avatar_url(speaker, mission_name):
+    return mission_static(mission_name, "images/avatars", speaker.avatar)
+
 
 @register.simple_tag
 def avatar_and_name(speaker, mission_name, timestamp=None):
@@ -11,20 +17,18 @@ def avatar_and_name(speaker, mission_name, timestamp=None):
         current_speaker = speaker.current_shift(timestamp)
     else:
         current_speaker = speaker
-    
+
     short_name_lang = ''
     if current_speaker.short_name_lang:
-        short_name_lang = " lang='%s'"  % current_speaker.short_name_lang 
-    
+        short_name_lang = " lang='%s'" % current_speaker.short_name_lang
+
     detail = """
-      <img src='%(MISSIONS_STATIC_URL)s%(mission_name)s/images/avatars/%(avatar)s' alt='' width='48' height='48'>
+      <img src='%(avatar)s' alt='' width='48' height='48'>
       <span%(short_name_lang)s>%(short_name)s</span>
     """ % {
-        "avatar": current_speaker.avatar,
+        "avatar": avatar_url(current_speaker, mission_name),
         "short_name": current_speaker.short_name,
         "short_name_lang": short_name_lang,
-        "mission_name": mission_name,
-        "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
     }
 
     url = None
@@ -50,13 +54,11 @@ def avatar(speaker, mission_name, timestamp=None):
     if current_speaker.short_name_lang:
         short_name_lang = " lang='%s'"  % current_speaker.short_name_lang 
     detail = """
-      <img src='%(MISSIONS_STATIC_URL)s%(mission_name)s/images/avatars/%(avatar)s' alt='' width='48' height='48' %(short_name_lang)salt='%(short_name)s'>
+      <img src='%(avatar)s' alt='' width='48' height='48' %(short_name_lang)salt='%(short_name)s'>
     """ % {
-        "avatar": current_speaker.avatar,
+        "avatar": avatar_url(current_speaker, mission_name),
         "short_name": current_speaker.short_name,
         "short_name_lang": short_name_lang,
-        "mission_name": mission_name,
-        "MISSIONS_STATIC_URL": settings.MISSIONS_STATIC_URL,
     }
 
     url = None

--- a/website/apps/transcripts/templatetags/missionstatic.py
+++ b/website/apps/transcripts/templatetags/missionstatic.py
@@ -1,0 +1,12 @@
+import os
+from django import template
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+
+def mission_static(mission, *path):
+    full_path = os.path.join('missions', mission, *path)
+    return staticfiles_storage.url(full_path)
+
+
+register = template.Library()
+register.simple_tag(mission_static)

--- a/website/apps/transcripts/templatetags/missionstatic.py
+++ b/website/apps/transcripts/templatetags/missionstatic.py
@@ -1,12 +1,58 @@
 import os
 from django import template
-from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.storage import (
+    StaticFilesStorage, staticfiles_storage,
+)
+
+
+def full_path(mission, *path):
+    """
+    Builds a full asset path from a mission name, and an arbitrary number of
+    path components.
+    """
+
+    return os.path.join('missions', mission, *path)
+
+
+def digest_free_static(path):
+    """
+    Bypasses the configured static files storage and uses the default
+    StaticFilesStorage class instead, to produce a URL that doesn't include
+    the digest of the file's current contents.
+
+    This is useful for passing URLs to the Open Graph, which will continue to
+    use the same URL more-or-less forever. If we gave it a digested URL, we
+    wouldn't be able to update the file.
+
+    As long as the configured static files storage is one of the standard
+    subclasss of StaticFilesStorage--like ManifestStaticFilesStorage--this
+    should all be fine.
+    """
+
+    digest_free_storage = StaticFilesStorage()
+    return digest_free_storage.url(path)
 
 
 def mission_static(mission, *path):
-    full_path = os.path.join('missions', mission, *path)
-    return staticfiles_storage.url(full_path)
+    """
+    Returns the URL of a mission static asset.
+    """
+
+    return staticfiles_storage.url(full_path(mission, *path))
+
+
+def digest_free_mission_static(mission, *path):
+    """
+    Returns the URL of a mission static asset, without the digest of the
+    file contents in the URL.
+
+    See digest_free_static for all the gory details.
+    """
+
+    return digest_free_static(full_path(mission, *path))
 
 
 register = template.Library()
+register.simple_tag(digest_free_static)
 register.simple_tag(mission_static)
+register.simple_tag(digest_free_mission_static)

--- a/website/apps/transcripts/templatetags/missionstatic.py
+++ b/website/apps/transcripts/templatetags/missionstatic.py
@@ -1,8 +1,14 @@
 import os
 from django import template
+from django.conf import settings
 from django.contrib.staticfiles.storage import (
-    StaticFilesStorage, staticfiles_storage,
+    get_storage_class, staticfiles_storage,
 )
+
+
+staticfiles_digest_free_storage = get_storage_class(
+    settings.STATICFILES_DIGEST_FREE_STORAGE,
+)()
 
 
 def full_path(mission, *path):
@@ -16,21 +22,16 @@ def full_path(mission, *path):
 
 def digest_free_static(path):
     """
-    Bypasses the configured static files storage and uses the default
-    StaticFilesStorage class instead, to produce a URL that doesn't include
-    the digest of the file's current contents.
+    Uses STATICFILES_DIGEST_FREE_STORAGE instead of STATICFILES_STORAGE
+    to produce a URL that doesn't include the digest of the file's current
+    contents.
 
     This is useful for passing URLs to the Open Graph, which will continue to
     use the same URL more-or-less forever. If we gave it a digested URL, we
     wouldn't be able to update the file.
-
-    As long as the configured static files storage is one of the standard
-    subclasss of StaticFilesStorage--like ManifestStaticFilesStorage--this
-    should all be fine.
     """
 
-    digest_free_storage = StaticFilesStorage()
-    return digest_free_storage.url(path)
+    return staticfiles_digest_free_storage.url(path)
 
 
 def mission_static(mission, *path):
@@ -49,7 +50,7 @@ def digest_free_mission_static(mission, *path):
     See digest_free_static for all the gory details.
     """
 
-    return digest_free_static(full_path(mission, *path))
+    return staticfiles_digest_free_storage.url(full_path(mission, *path))
 
 
 register = template.Library()

--- a/website/configs/live/settings.py
+++ b/website/configs/live/settings.py
@@ -5,12 +5,10 @@ ALLOWED_HOSTS = [
 ]
 
 # The following MUST be an absolute URL in live deploys (it's given out
-# to other systems). Also, it doesn't get overridden in local_settings.py
-# unlike the others.
-FIXED_MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'
+# to other systems).
+MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'
 
 STATIC_URL = 'http://cdn.spacelog.org/assets/website/'
-MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'
 MISSIONS_IMAGE_URL = 'http://media.spacelog.org/'
 
 # allow local overrides, probably built during deploy

--- a/website/configs/live/settings.py
+++ b/website/configs/live/settings.py
@@ -6,8 +6,6 @@ ALLOWED_HOSTS = [
 
 # The following MUST be an absolute URL in live deploys (it's given out
 # to other systems).
-MISSIONS_STATIC_URL = 'http://cdn.spacelog.org/assets/website/missions/'
-
 STATIC_URL = 'http://cdn.spacelog.org/assets/website/'
 MISSIONS_IMAGE_URL = 'http://media.spacelog.org/'
 

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -54,6 +54,7 @@ MEDIA_ROOT = ''
 MEDIA_URL = ''
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -59,9 +59,6 @@ STATIC_URL = '/assets/'
 # places on the CDN
 MISSIONS_STATIC_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
 MISSIONS_STATIC_URL = '/assets/missions/'
-# FIXED_MISSIONS_STATIC_URL doesn't change with varying deploys, so can be used for
-# things that need long-term URLs, like image references in the Open Graph.
-FIXED_MISSIONS_STATIC_URL = '/assets/missions/'
 MISSIONS_IMAGE_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
 # Set this to '/assets/missions/' if you want to test local mission images
 MISSIONS_IMAGE_URL = 'http://media.spacelog.org/'

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -53,6 +53,7 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -53,12 +53,22 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
-STATIC_ROOT = os.path.join(SITE_ROOT, 'static')
+STATICFILES_DIRS = [
+    os.path.join(SITE_ROOT, 'static'),
+]
+
+MISSIONS_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
+for mission_name in os.listdir(MISSIONS_ROOT):
+    mission_image_path = os.path.join(MISSIONS_ROOT, mission_name, 'images')
+    if os.path.isdir(mission_image_path):
+        STATICFILES_DIRS += [
+            ("missions/%s/images" % mission_name, mission_image_path),
+        ]
+
+STATIC_ROOT = os.path.join(SITE_ROOT, 'collected')
 STATIC_URL = '/assets/'
 # in dev, these come from the same place; in live, they'll be in different
 # places on the CDN
-MISSIONS_STATIC_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
-MISSIONS_STATIC_URL = '/assets/missions/'
 MISSIONS_IMAGE_ROOT = os.path.join(SITE_ROOT, '..', 'missions')
 # Set this to '/assets/missions/' if you want to test local mission images
 MISSIONS_IMAGE_URL = 'http://media.spacelog.org/'
@@ -101,6 +111,7 @@ ROOT_URLCONF = 'urls'
 
 INSTALLED_APPS = (
     'django.contrib.humanize',
+    'django.contrib.staticfiles',
     'common',
     'search',
     'transcripts',

--- a/website/static/js/global.js
+++ b/website/static/js/global.js
@@ -47,25 +47,20 @@ $.event.special.scrollstop = {
 // End jQuery cribbed code
 
 (function() {
-    var Artemis = {
-        animationTime: 250,
+    Artemis.animationTime = 250;
 
-        // Parses a mission timestamp from a URL and converts it to a number of 
-        // seconds
-        parseMissionTime: function(mission_time) {
-            t = _.map(mission_time.split(':'), function(i) {
-                return parseInt(i, 10);
-            });
-            return t[3] + t[2]*60 + t[1]*3600 + t[0]*86400;
-        },
+    // Parses a mission timestamp from a URL and converts it to a number of
+    // seconds
+    Artemis.parseMissionTime = function(mission_time) {
+        t = _.map(mission_time.split(':'), function(i) {
+            return parseInt(i, 10);
+        });
+        return t[3] + t[2]*60 + t[1]*3600 + t[0]*86400;
+    };
 
-        replaceWithSpinner: function(e, white) {
-            var suffix = '';
-            if (white) {
-                suffix = '-white';
-            }
-            $(e).replaceWith('<img src="/assets/img/ajax-loader'+suffix+'.gif" alt="">');
-        }
+    Artemis.replaceWithSpinner = function(e, white) {
+        var src = white ? Artemis.assets.spinnerWhite : Artemis.assets.spinner;
+        $(e).replaceWith('<img src="' + src + '" alt="">');
     };
 
     Artemis.HomepageQuoteView = Backbone.View.extend({
@@ -156,7 +151,5 @@ $.event.special.scrollstop = {
             }
         }
     });
-
-    window.Artemis = Artemis;
 })();
 

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}{% load missionstatic %}<!DOCTYPE html>
+{% load staticfiles %}{% load missionstatic %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -19,8 +19,8 @@
   <meta property="og:type" content="space:MannedMission">
   <link rel="rdfs:type" resource="http://spacelog.org/ns/MannedMission">
   <meta property="og:url foaf:homepage" content="http://{{ request.META.HTTP_HOST }}/">
-  <meta property="og:image" content="{{ FIXED_MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
-  <link property="foaf:depiction" href="{{ FIXED_MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
+  <meta property="og:image" content="{{ MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
+  <link property="foaf:depiction" href="{{ MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
   {% comment %}
       foaf:depiction and og:image are being repeated as separate properties because the Open Graph Protocol
       is misusing RDFa slightly: in RDFa, the content attribute is used to represent literals (strings basically).

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -19,8 +19,8 @@
   <meta property="og:type" content="space:MannedMission">
   <link rel="rdfs:type" resource="http://spacelog.org/ns/MannedMission">
   <meta property="og:url foaf:homepage" content="http://{{ request.META.HTTP_HOST }}/">
-  <meta property="og:image" content="{% mission_static mission.name "images/badge.png" %}">
-  <link property="foaf:depiction" href="{% mission_static mission.name "images/badge.png" %}">
+  <meta property="og:image" content="{% digest_free_mission_static mission.name "images/badge.png" %}">
+  <link property="foaf:depiction" href="{% digest_free_mission_static mission.name "images/badge.png" %}">
   {% comment %}
       foaf:depiction and og:image are being repeated as separate properties because the Open Graph Protocol
       is misusing RDFa slightly: in RDFa, the content attribute is used to represent literals (strings basically).

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"
@@ -10,8 +10,8 @@
       lang="en-us">
 <head>
   <title>{% block full_title %}{% block title %}SET THE TITLE{% endblock %} &mdash; {{ mission.title }} on Spacelog{% endblock %}</title>
-  <link rel="stylesheet" href="{{ STATIC_URL }}css/screen.css" media="screen">
-  <link rel="shortcut icon" href="{{ STATIC_URL}}img/favicon.ico">
+  <link rel="stylesheet" href="{% static "css/screen.css" %}" media="screen">
+  <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
   {% block extra_head %}{% endblock %}
 {% if mission %}
   <meta name="description" property="og:description dbo:abstract" content="Read the original story of {{ mission.title }}: {{ mission.description }}">
@@ -56,13 +56,13 @@
 {% block content %}{% endblock %}
 </div></div>
 
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery-1.4.4.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery-ui-1.8.6.just-animations.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery.placeholder.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery.cookie.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/underscore-min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/backbone-min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/global.js"></script>
+<script type="text/javascript" src="{% static "js/jquery-1.4.4.min.js" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery-ui-1.8.6.just-animations.min.js" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery.placeholder.js" %}"></script>
+<script type="text/javascript" src="{% static "js/jquery.cookie.js" %}"></script>
+<script type="text/javascript" src="{% static "js/underscore-min.js" %}"></script>
+<script type="text/javascript" src="{% static "js/backbone-min.js" %}"></script>
+<script type="text/javascript" src="{% static "js/global.js" %}"></script>
 {% block extra_js %}{% endblock %}
 <script type="text/javascript">
   (function() {

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}<!DOCTYPE html>
+{% load static %}{% load missionstatic %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"
@@ -19,8 +19,8 @@
   <meta property="og:type" content="space:MannedMission">
   <link rel="rdfs:type" resource="http://spacelog.org/ns/MannedMission">
   <meta property="og:url foaf:homepage" content="http://{{ request.META.HTTP_HOST }}/">
-  <meta property="og:image" content="{{ MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
-  <link property="foaf:depiction" href="{{ MISSIONS_STATIC_URL }}{{ mission.name}}/images/badge.png">
+  <meta property="og:image" content="{% mission_static mission.name "images/badge.png" %}">
+  <link property="foaf:depiction" href="{% mission_static mission.name "images/badge.png" %}">
   {% comment %}
       foaf:depiction and og:image are being repeated as separate properties because the Open Graph Protocol
       is misusing RDFa slightly: in RDFa, the content attribute is used to represent literals (strings basically).

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -56,6 +56,14 @@
 {% block content %}{% endblock %}
 </div></div>
 
+<script type="text/javascript">
+window.Artemis = {
+  assets: {
+    spinner: "{% static "img/ajax-loader.gif" %}",
+    spinnerWhite: "{% static "img/ajax-loader-white.gif" %}"
+  }
+};
+</script>
 <script type="text/javascript" src="{% static "js/jquery-1.4.4.min.js" %}"></script>
 <script type="text/javascript" src="{% static "js/jquery-ui-1.8.6.just-animations.min.js" %}"></script>
 <script type="text/javascript" src="{% static "js/jquery.placeholder.js" %}"></script>

--- a/website/templates/homepage/about.html
+++ b/website/templates/homepage/about.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load missionstatic %}
 {% load missiontime %}
 {% load nbspify %}
 
@@ -9,7 +10,7 @@
   <h1>{{ mission.copy.based_on_header }}</h1>
   <div id='coverpage'>
     {% if mission.copy.about_image %}
-    <img src='{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/{{ mission.copy.about_image }}' width='270' alt=''>
+    <img src='{% mission_static mission.name "images" mission.copy.about_image %}' width='270' alt=''>
     {% else %}
     <a href='{% url "original" 1 %}'>
         <img src='{{ MISSIONS_IMAGE_URL }}{{ mission.name }}/images/original/TEC/about.png'

--- a/website/templates/homepage/homepage.html
+++ b/website/templates/homepage/homepage.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}
 {% load pauses %}
 
 {% block full_title %}{{ mission.title }} transcripts on Spacelog{% endblock %}
 {% block content-class %}homepage{% endblock %}
-{% block content-extra %}style="background:url({{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/homepage/background.jpg) top left no-repeat;"{% endblock %}
+{% block content-extra %}style="background:url({% mission_static mission.name "images/homepage/background.jpg" %}) top left no-repeat;"{% endblock %}
 
 {% block content %}
 <div class='crest'>
@@ -24,7 +25,7 @@
     <a href='{% timestamp_to_url act.start %}'>
     {% endifequal %}
         {% if act.homepage %}
-        <img src="{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/homepage/{{ act.homepage }}"
+        <img src="{% mission_static mission.name "images/homepage" act.homepage %}"
            alt="" width="220" height="140"/>
         {% endif %}
       Phase {{ number }}: {{ act.title }}

--- a/website/templates/people/_person.html
+++ b/website/templates/people/_person.html
@@ -1,10 +1,11 @@
+{% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}
 
 <div class="person" id="{{ person.slug }}">
   <h3>
     {% if person.photo %}
-      <img src="{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/people/{{ person.photo }}" alt=""
+      <img src="{% mission_static mission.name "images/people" person.photo %}" alt=""
          width="{{ person.photo_width }}" height="{{ person.photo_height }}">
     {% endif %}
     <em{% if person.name_lang %} lang="{{ person.name_lang }}"{% endif %}>{{ person.name }}</em>

--- a/website/templates/people/_simple_person.html
+++ b/website/templates/people/_simple_person.html
@@ -1,9 +1,10 @@
 {# NOTE: This template exists solely for the purpose of testing styling. #}
+{% load missionstatic %}
 
 <div class="person" id="{{ person.slug }}">
   <h3>
     {% if person.photo %}
-    <img src="{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/people/{{ person.photo }}" alt=""
+    <img src="{% mission_static mission.name "images/people" person.photo %}" alt=""
          width="{{ person.photo_width }}" height="{{ person.photo_height }}">
     {% endif %}
     <em{% if person.name_lang %} lang="{{ person.name_lang }}"{% endif %}>{{ person.name }}</em>

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 {% load missiontime %}
 {% load linkify %}
 {% load pauses %}
@@ -14,7 +15,7 @@
 {% endif %}
 {% endif %}{% endblock %}
 
-{% block extra_js %}<script type="text/javascript" src="{{ STATIC_URL }}js/page.js"></script>{% endblock %}
+{% block extra_js %}<script type="text/javascript" src="{% static "js/page.js" %}"></script>{% endblock %}
 
 
 {% block content-class %}transcript {% if max_highlight_index > 0 %}with-highlight{% endif %}{% endblock %}

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load staticfiles %}
 {% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}
 {% load pauses %}
@@ -27,7 +28,7 @@
     <div id='crest' {% if act.banner_class %}class='{{ act.banner_class }}'{% endif %} {% if act.banner_styles %}style='{{ act.banner_styles }}'{% endif %}><div class='wrapper'>
       <p class='act-banner'>
         {% if act.banner %}
-          <img src="{{ MISSIONS_STATIC_URL }}{{ act.mission_name }}/images/banners/{{ act.banner }}" alt="Phase {{ act.number|add:1 }}: {{ act.title }}">
+          <img src="{% mission_static act.mission_name "images/banners" act.banner %}" alt="Phase {{ act.number|add:1 }}: {{ act.title }}">
         {% else %}
           Phase {{ act.number|add:1 }}: <b>{{ act.title }}</b>
         {% endif %}
@@ -171,7 +172,7 @@
         </li>
       </ul></nav>
       {% if current_act.orbital %}
-      <img class='orbital' src='{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/orbital/{{ current_act.orbital }}'>
+      <img class='orbital' src='{% mission_static mission.name "images/orbital" current_act.orbital %}'>
       {% endif %}
     </div></div>
   </div>

--- a/website/templates/transcripts/phases.html
+++ b/website/templates/transcripts/phases.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}
 {% load humanize %}
@@ -11,7 +12,7 @@
 {% block content %}
 
   {% if act.illustration %}
-  <img class='illustration' src='{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/illustration/{{ act.illustration }}' alt='' />
+  <img class='illustration' src='{% mission_static mission.name "images/illustration" act.illustration %}' alt='' />
   {% endif %}
 
   <div class='league-gothic navigation'>
@@ -48,7 +49,7 @@
           <em class='end'>{{ act.end|mission_time_format }}</em>
         </p>
         {{ act.stats_image_map|safe }}
-        <img src='{{ MISSIONS_STATIC_URL }}{{ mission.name }}/images/stats/graph_{{ mission.name }}_{{ act.number }}.png' alt='Frequency of lines in {{ act.title }}' usemap='#{{ act.stats_image_map_id }}' />
+        <img src='{% mission_static mission.name "images/stats" act.stats_image %}' alt='Frequency of lines in {{ act.title }}' usemap='#{{ act.stats_image_map_id }}' />
       </div>
     {% endif %}
 

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, url
 from django.conf import settings
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from transcripts.views import PageView, PhasesView, RangeView, ErrorView, OriginalView
 from homepage.views import HomepageView, HomepageQuoteView
 from search.views import SearchView
@@ -25,24 +26,4 @@ urlpatterns = patterns('',
     url(r'^original/(?:(?P<transcript>[-_\w]+)/)?(?P<page>-?\d+)/$', OriginalView.as_view(), name="original"),
 )
 
-if settings.DEBUG: # pragma: no cover
-    urlpatterns += patterns('',
-        (r'^' + settings.MISSIONS_STATIC_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.MISSIONS_STATIC_ROOT
-        }),
-        (r'^' + settings.MISSIONS_IMAGE_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.MISSIONS_IMAGE_ROOT
-        }),
-        (r'^' + settings.STATIC_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.STATIC_ROOT
-        }),
-        # (r'^' + settings.MEDIA_URL[1:] + '(?P<path>.*)$', 'django.views.static.serve', {
-        #     'document_root': settings.MEDIA_ROOT
-        # }),
-        (r'^404/$', ErrorView.as_view()),
-        (r'^500/$', ErrorView.as_view(error_code=500)),
-    )
-
-handler404 = ErrorView.as_view()
-handler500 = ErrorView.as_view(error_code=500)
-
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Replaces our custom static file handling code, with a more normal `django.contrib.staticfiles` setup. See #229 for background.

The most unconventional part of this is circumventing the `ManifestStaticFilesStorage` to avoid content digests in the URLs we give to the open graph. Details in 2efc080ff6226bdc98d22eb0a356be892e07ee31