### PR TITLE
Gloss the Emergency Detection System

### DIFF
--- a/missions/a11/transcripts/CM
+++ b/missions/a11/transcripts/CM
@@ -1372,7 +1372,7 @@ CMP: Now, let's see. We want to go to the suit circuit - -
 LMP: Yes, I'll get the suit circuit if I can find that valve.
 
 [00:01:54:50]
-CMP: Okay, let's see, that's the EDS POWER, ON.
+CMP: Okay, let's see, that's the [glossary:EDS] POWER, ON.
 
 [00:01:54:54]
 LMP: Oh, that thing is hard.
@@ -1387,10 +1387,10 @@ LMP: Suit's closed.
 CMP: - - on that VERB 48?
 
 [00:01:55:10]
-CDR: Ready for EDS POWER, ON, you think?
+CDR: Ready for [glossary:EDS] POWER, ON, you think?
 
 [00:01:55:13]
-CMP: EDS POWER, up and ON, yes.
+CMP: [glossary:EDS] POWER, up and ON, yes.
 
 [00:01:55:17]
 CDR: Okay, it's ON.
@@ -2188,10 +2188,10 @@ CMP: You got that TRANSLUNAR switched to INJECT, huh?
 CDR: Yes, to INJECT.
 
 [00:02:23:47]
-LMP: EDS POWER, you got ON?
+LMP: [glossary:EDS] POWER, you got ON?
 
 [00:02:23:49]
-CDR: EDS POWER is ON.
+CDR: [glossary:EDS] POWER is ON.
 
 [00:02:23:53]
 LMP: PYROs are ARMED?

--- a/missions/a13/transcripts/TEC
+++ b/missions/a13/transcripts/TEC
@@ -80,7 +80,7 @@ CDR: I Charlie.
 CC:  And, 13, you are GO for staging.
 
 [00:00:02:04]
-CDR: GO for staging. Roger. We're EDS MANUAL.
+CDR: GO for staging. Roger. We're [glossary:EDS] MANUAL.
 
 [00:00:02:08]
 _page : 9
@@ -27347,7 +27347,7 @@ CMP: Oh, that's right. Oh, I knew that. I'm not
 
 [03:20:00:19]
 CC:  Okay. Now the next one, two, three, four, five
-     are the same, and we want EDS AUTO to OFF. Over.
+     are the same, and we want [glossary:EDS] AUTO to OFF. Over.
 
 [03:20:00:33]
 CMP: Okay.
@@ -27404,7 +27404,7 @@ CMP: Okay. And that's exactly where I was. COMMAND
      MODULE [glossary:RCS] PROPELLANT 2, center, on, up; PROPELLANT 
      talkbacks, two, gray; SERVICE MODULE [glossary:RCS]
      SECONDARY FUEL PRESSURE, four, center, and
-     CLOSED; EDS AUTO, OFF; COMMAND MODULE/[glossary:LM] FINAL
+     CLOSED; [glossary:EDS] AUTO, OFF; COMMAND MODULE/[glossary:LM] FINAL
      SEP, two, off; COMMAND MODULE/SERVICE MODULE
      SEP, two, down; [glossary:S-IVB]/[glossary:LM] SEP, off, down, guarded;
      PROPELLANT DUMP to [glossary:RCS] COMMAND; 2 ENGINE OUT and
@@ -27653,7 +27653,7 @@ CC:  Okay. On panel 6, skip the first one. We want
 CMP: All right.
 
 [03:20:14:27]
-CC:  Okay. On panel 7 we want EDS POWER, OFF. [glossary:TVC] SERVO
+CC:  Okay. On panel 7 we want [glossary:EDS] POWER, OFF. [glossary:TVC] SERVO
      POWER 1 and 2, OFF; [glossary:FDAI]/GPI POWER, OFF; and LOGIC 2
      slash 3 POWER, OFF. Over.
 
@@ -27708,12 +27708,12 @@ CC:  Okay. And SEQ ARM, two, open.
 CMP: Okay. Are you with me? SEQ ARM, two of them open.
 
 [03:20:17:58]
-CC:  Roger. The next is EDS, three, to open.
+CC:  Roger. The next is [glossary:EDS], three, to open.
 
 [03:20:18:05]
 _page : 438
 _tape : Tape 62/15
-CMP: EDS, three, open.
+CMP: [glossary:EDS], three, open.
 
 [03:20:18:08]
 CC:  Roger. The next are ELS BAT A, BAT B, two, open.
@@ -32022,7 +32022,7 @@ CMP: Okay. On panel 3: TRANSPONDER to PRIMARY;
 CC:  Hey, very good. Okay, panel 225: circuit
      breaker FLIGHT BUS, MAIN B, to close; circuit
      breaker CTE, MAIN B, to close. Panel 250: CB
-     BAT C BAT CHARGER/EDS 2 to close.
+     BAT C BAT CHARGER/[glossary:EDS] 2 to close.
 
 [04:05:15:18]
 CMP: Hey, Vance, just a minute. Slow down, would you?
@@ -32037,7 +32037,7 @@ CMP: Okay. I got distracted here. On panel 225: CB
 
 [04:05:15:37]
 CC:  Okay. After that, CB CTE, MAIN B, to close.
-     Next, panel 250: CB BAT C BAT CHARGE/EDS2 to
+     Next, panel 250: CB BAT C BAT CHARGE/[glossary:EDS]2 to
      close; CB BAT C POWER ENTRY/POSTLANDING to
      close. Next, panel 275: CB MAIN B, BAT BUS B,
      to close; CB INVERTER POWER 2, MAIN B, to close.
@@ -32052,7 +32052,7 @@ CMP: Okay. Let me give you all of panel 225 again.
      CB FLIGHT BUS, MAIN B, close; CB CTE, MAIN B,
      close. On panel 250: CB BAT - B BAT CHARGE,
      that should be BAT C, Charlie, isn't it? BAT
-     CHARGE/EDS2 closed?
+     CHARGE/[glossary:EDS]2 closed?
 
 [04:05:18:01]
 CC:  That's right. That's - -
@@ -32065,7 +32065,7 @@ CC:  Okay. That should be BAT Charlie.
 
 [04:05:18:08]
 CMP: Let me finish. Okay. That's what I thought.
-     BAT Charlie BAT CHARGE/EDS2, close; BAT Baker
+     BAT Charlie BAT CHARGE/[glossary:EDS]2, close; BAT Baker
      POWER ENTRY/POSTLANDING, closed. On panel 275:
      CB MAIN B, BAT BUS B, closed; CB INVERTER POWER 2,
      MAIN B, closed.

--- a/missions/a8/transcripts/TEC
+++ b/missions/a8/transcripts/TEC
@@ -30966,7 +30966,7 @@ CC: Alright. Still on page E-9 and under step 39
      a step that says panel 8, all circuit breakers 
      CLOSED except and then it lists five that are 
      printed, one that was pen-and-inked before 
-     launch. It says EDS power circuit breakers 3 
+     launch. It says [glossary:EDS] power circuit breakers 3 
      OPEN, and to be complete, we ought to add the 
      [glossary:RCS] heater circuit breakers. There's two of 
      those, and they should also be OPEN. 

--- a/missions/shared/glossary/apollo
+++ b/missions/shared/glossary/apollo
@@ -143,6 +143,11 @@
         "summary": "Environmental control system",
         "type": "abbreviation"
     },
+    "EDS": {
+        "summary": "Emergency detection system",
+        "type": "abbreviation",
+        "description": "The emergency detection system monitored the flight vehicle during the early stages of the launch. It could trigger an automatic abort in situations where the flight crew could not be expected to react quickly enough to ensure a successful escape from the booster."
+    },
     "EI": {
         "summary": "Entry interface",
         "type": "abbreviation"


### PR DESCRIPTION
The Emergency Detection System (EDS) was the monitoring system used to trigger an automatic abort in the early stages of launch.

Gloss this where it appears in Apollo transcripts.

Fair warning: I have absolutely no idea what I'm doing in this codebase. I will have a look at setting up a proper development environment soon, so please feel free to explain if this is completely the wrong way to go about this and I'll do my best to fix it up.