### PR TITLE
Upgrade to Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /src
 COPY requirements.txt /src/
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install -r requirements.txt
 COPY . /src/
+ENV PYTHONIOENCODING utf-8:ignore
 RUN /etc/init.d/redis-server start && \
   make all && \
   redis-cli shutdown save

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ CMD ["overmind", "start"]
 RUN apt-get update -qq && \
     apt-get install -yq \
         imagemagick optipng procps \
-        python python-pip python-xapian \
+        python3 python3-pip python3-xapian \
         redis-server \
         nginx
 ENV PYTHONUNBUFFERED 1
@@ -25,7 +25,7 @@ RUN mkdir -p /src
 
 WORKDIR /src
 COPY requirements.txt /src/
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install -r requirements.txt
 COPY . /src/
 RUN /etc/init.d/redis-server start && \
   make all && \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ website_scss_components   = $(wildcard website/static/css/*/*.scss)
 global_scss_sources       = $(wildcard global/static/css/*.scss)
 global_css_targets        = $(patsubst %.scss,%.css,$(global_scss_sources))
 global_scss_components    = $(wildcard global/static/css/*/*.scss)
-PYTHON                   ?= python
+PYTHON                   ?= python3
 SASS                     ?= pyscss
 
 # Dev Django runserver variables

--- a/backend/api.py
+++ b/backend/api.py
@@ -29,7 +29,7 @@ class BaseQuery(object):
         return self.__class__(self.redis_conn, self.mission_name, new_filters)
 
     def __iter__(self):
-        return iter( list(self.items()) )
+        yield from self.items()
     
 
 class LogLine(object):

--- a/backend/api.py
+++ b/backend/api.py
@@ -64,7 +64,7 @@ class LogLine(object):
 
         self.lines = []
         for line in self.redis_conn.lrange("log_line:%s:lines" % self.id, 0, -1):
-            line = line.decode('utf-8')
+            line = line
             speaker_identifier, text = [x.strip() for x in line.split(":", 1)]
             speaker = Character(self.redis_conn, self.mission_name, speaker_identifier)
             self.lines += [[speaker, text]]
@@ -140,7 +140,7 @@ class LogLine(object):
 
     def labels(self):
         "Returns the labels for this LogLine."
-        return [x.decode('utf-8') for x in self.redis_conn.smembers("log_line:%s:labels" % self.id)]
+        return [x for x in self.redis_conn.smembers("log_line:%s:labels" % self.id)]
 
     class Query(BaseQuery):
         """
@@ -230,27 +230,27 @@ class LogLine(object):
             # Make sure it's a valid combination 
             filter_names = set(self.filters.keys())
             if filter_names == set():
-                keys = [x.decode('utf-8') for x in self.redis_conn.zrange(self.all_key, 0, -1)]
+                keys = [x for x in self.redis_conn.zrange(self.all_key, 0, -1)]
             elif filter_names == set(["transcript"]):
-                keys = [x.decode('utf-8') for x in self.redis_conn.zrange("transcript:%s" % self.filters['transcript'], 0, -1)]
+                keys = [x for x in self.redis_conn.zrange("transcript:%s" % self.filters['transcript'], 0, -1)]
             elif filter_names == set(["transcript", "range"]):
-                keys = [x.decode('utf-8') for x in self.redis_conn.zrangebyscore(
+                keys = [x for x in self.redis_conn.zrangebyscore(
                     "transcript:%s" % self.filters['transcript'],
                     self.filters['range'][0],
                     self.filters['range'][1],
                 )]
             elif filter_names == set(["range"]):
-                keys = [x.decode('utf-8') for x in self.redis_conn.zrangebyscore(
+                keys = [x for x in self.redis_conn.zrangebyscore(
                     self.all_key,
                     self.filters['range'][0],
                     self.filters['range'][1],
                 )]
             elif filter_names == set(['page', 'transcript']):
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange("page:%s:%i" % (self.filters['transcript'], self.filters['page']), 0, -1)]
+                keys = [x for x in self.redis_conn.lrange("page:%s:%i" % (self.filters['transcript'], self.filters['page']), 0, -1)]
             elif filter_names == set(['transcript_page', 'transcript']):
                 index_key = "transcript_page:%s:%s" % (self.filters['transcript'], self.filters['transcript_page'])
                 raw_keys = self.redis_conn.lrange(index_key, 0, -1)
-                keys = [x.decode('utf-8') for x in raw_keys]
+                keys = [x for x in raw_keys]
             else:
                 raise ValueError("Invalid combination of filters: %s" % ", ".join(filter_names))
             # Iterate over the keys and return LogLine objects
@@ -316,10 +316,10 @@ class NarrativeElement(object):
             # Make sure it's a valid combination 
             filter_names = set(self.filters.keys())
             if filter_names == set():
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange(self.all_key, 0, -1)]
+                keys = [x for x in self.redis_conn.lrange(self.all_key, 0, -1)]
             elif filter_names == set(['act_number']):
                 redis_key = 'act:%s:%s:key_scenes' % (self.mission_name, self.filters['act_number'])
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange(redis_key, 0, -1)]
+                keys = [x for x in self.redis_conn.lrange(redis_key, 0, -1)]
             else:
                 raise ValueError("Invalid combination of filters: %s" % ", ".join(filter_names))
             # Iterate over the keys and return LogLine objects
@@ -420,12 +420,12 @@ class Character(object):
         data = self.redis_conn.hgetall( key )
         bio = data.get('bio', None)
         if bio is not None:
-            bio = bio.decode('utf-8')
+            bio = bio
         
         self.identifier_lang      = data.get('identifier_lang', None)
-        self.name                 = data.get('name', self.identifier.encode('utf-8')).decode('utf-8')
+        self.name                 = data.get('name', self.identifier)
         self.name_lang            = data.get('name_lang', None)
-        self.short_name           = data.get('short_name', self.identifier.encode('utf-8')).decode('utf-8')
+        self.short_name           = data.get('short_name', self.identifier)
         self.short_name_lang      = data.get('short_name_lang', None)
         self.role                 = data.get('role', 'other')
         self.mission_position     = data.get('mission_position', '')
@@ -436,7 +436,7 @@ class Character(object):
         self.photo_width          = data.get('photo_width', None)
         self.photo_height         = data.get('photo_height', None)
         self.quotable_log_line_id = data.get('quotable_log_line_id', None)
-        self.quote                = data.get('quote', '').decode('utf-8')
+        self.quote                = data.get('quote', '')
         self.precomputed_slug     = data.get('slug', None)
         
         stat_pairs = self.redis_conn.lrange( "%s:stats" % key, 0, -1 )
@@ -472,7 +472,7 @@ class Character(object):
         shifts_key = 'characters:%s:shifts' % self.id
         shifts = self.redis_conn.zrangebyscore(shifts_key, -86400, timestamp)
         if shifts:
-            shift_start, character_identifier = shifts[-1].decode('utf-8').split(':')
+            shift_start, character_identifier = shifts[-1].split(':')
             return Character(self.redis_conn, self.mission_name, character_identifier)
         else:
             return self
@@ -493,10 +493,10 @@ class Character(object):
             
             filter_names = set(self.filters.keys())
             if filter_names == set():
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange(self.all_key, 0, -1)]
+                keys = [x for x in self.redis_conn.lrange(self.all_key, 0, -1)]
             elif filter_names == set(['role']):
                 role_key = self.role_key_pattern % {'mission_name':self.mission_name, 'role':self.filters['role']}
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange(role_key, 0, -1)]
+                keys = [x for x in self.redis_conn.lrange(role_key, 0, -1)]
             else:
                 raise ValueError("Invalid combination of filters: %s" % ", ".join(filter_names))
             
@@ -523,7 +523,7 @@ class Glossary(object):
         data = self.redis_conn.hgetall( key )
         if not data:
             raise ValueError("No such glossary item: %s (%s)" % (self.id, key))
-        self.description               = data['description'].decode('utf-8')
+        self.description               = data['description']
         self.description_lang          = data.get('description_lang', None)
         self.extended_description      = data.get('extended_description', None)
         self.extended_description_lang = data.get('extended_description_lang', None)
@@ -556,7 +556,7 @@ class Glossary(object):
             
             filter_names = set(self.filters.keys())
             if filter_names == set():
-                keys = [x.decode('utf-8') for x in self.redis_conn.lrange(self.all_key, 0, -1)]
+                keys = [x for x in self.redis_conn.lrange(self.all_key, 0, -1)]
             else:
                 raise ValueError("Invalid combination of filters: %s" % ", ".join(filter_names))
             
@@ -625,7 +625,7 @@ class Mission(object):
             filter_names = set(self.filters.keys())
             if filter_names == set():
                 keys = [
-                    x.decode('utf-8').split(":")[1]
+                    x.split(":")[1]
                     for x in self.redis_conn.keys("mission:*")
                     if len(x.split(":")) == 2
                 ]

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -13,7 +13,7 @@ from django.utils.html import strip_tags
 
 from backend.parser import TranscriptParser, MetaParser
 from backend.api import Act, KeyScene, Character, Glossary, LogLine
-from backend.util import seconds_to_timestamp
+from backend.util import redis_connection, seconds_to_timestamp
 
 search_db = xappy.IndexerConnection(
     os.path.join(os.path.dirname(__file__), '..', 'xappydb'),
@@ -604,10 +604,6 @@ class MissionIndexer(object):
 
 
 if __name__ == "__main__":
-    redis_conn = redis.from_url(
-        os.environ.get("REDIS_URL", "redis://localhost:6379"),
-        decode_responses=True
-    )
     transcript_dir = os.path.join(os.path.dirname( __file__ ), '..', "missions")
     dirs = os.listdir(transcript_dir)
 
@@ -617,6 +613,6 @@ if __name__ == "__main__":
         path = os.path.join(transcript_dir, filename)
         if filename[0] not in "_." and os.path.isdir(path) and os.path.exists(os.path.join(path, "transcripts", "_meta")):
             print("Mission: %s" % filename)
-            idx = MissionIndexer(redis_conn, filename, os.path.join(path, "transcripts")) 
+            idx = MissionIndexer(redis_connection, filename, os.path.join(path, "transcripts"))
             idx.index()
     search_db.flush()

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -604,7 +604,10 @@ class MissionIndexer(object):
 
 
 if __name__ == "__main__":
-    redis_conn = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379"))
+    redis_conn = redis.from_url(
+        os.environ.get("REDIS_URL", "redis://localhost:6379"),
+        decode_responses=True
+    )
     transcript_dir = os.path.join(os.path.dirname( __file__ ), '..', "missions")
     dirs = os.listdir(transcript_dir)
 

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -146,7 +146,7 @@ class TranscriptIndexer(object):
                 doc.fields.append(xappy.Field("speaker", line['speaker']))
         doc.id = id
         try:
-            search_db.replace(search_db.process(doc))
+            search_db.add(doc)
         except xappy.errors.IndexerError:
             print("umm, error")
             print(id, lines)
@@ -171,7 +171,7 @@ class TranscriptIndexer(object):
         for chunk in self.parser.get_chunks():
             timestamp = chunk['timestamp']
             log_line_id = "%s:%i" % (self.transcript_name, timestamp)
-            if timestamp <= previous_timestamp:
+            if previous_timestamp and timestamp <= previous_timestamp:
                 raise Exception("%s should be after %s" % (seconds_to_timestamp(timestamp), seconds_to_timestamp(previous_timestamp)))
             # See if there's transcript page info, and update it if so
             if chunk['meta'].get('_page', 0):

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -509,7 +509,10 @@ class MetaIndexer(object):
         shared_glossary_files_path  = os.path.join(os.path.dirname( __file__ ), '..', 'missions', 'shared', 'glossary')
         
         for filename in shared_glossary_files:
-            with open(os.path.join(shared_glossary_files_path, filename)) as fh:
+            with open(
+                os.path.join(shared_glossary_files_path, filename),
+                encoding="utf-8"
+            ) as fh:
                 glossary_terms.update(json.load(fh))
         
         # Add the mission specific glossary terms

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 import os
 import sys
 import re
@@ -21,7 +21,7 @@ search_db = xappy.IndexerConnection(
 
 def mission_time_to_timestamp(mission_time):
     """Takes a mission time string (XX:XX:XX:XX) and converts it to a number of seconds"""
-    d,h,m,s = map(int, mission_time.split(':'))
+    d,h,m,s = list(map(int, mission_time.split(':')))
     timestamp = d*86400 + h*3600 + m*60 + s
     
     if mission_time[0] == "-":
@@ -96,7 +96,7 @@ class TranscriptIndexer(object):
             xappy.FieldActions.STORE_CONTENT,
         )
         # Add names as synonyms for speaker identifiers
-        characters = Character.Query(self.redis_conn, self.mission_name).items()
+        characters = list(Character.Query(self.redis_conn, self.mission_name).items())
         self.characters = {}
         for character in characters:
             self.characters[character.identifier] = character
@@ -148,8 +148,8 @@ class TranscriptIndexer(object):
         try:
             search_db.replace(search_db.process(doc))
         except xappy.errors.IndexerError:
-            print "umm, error"
-            print id, lines
+            print("umm, error")
+            print(id, lines)
             raise
 
     def index(self):
@@ -172,7 +172,7 @@ class TranscriptIndexer(object):
             timestamp = chunk['timestamp']
             log_line_id = "%s:%i" % (self.transcript_name, timestamp)
             if timestamp <= previous_timestamp:
-                raise Exception, "%s should be after %s" % (seconds_to_timestamp(timestamp), seconds_to_timestamp(previous_timestamp))
+                raise Exception("%s should be after %s" % (seconds_to_timestamp(timestamp), seconds_to_timestamp(previous_timestamp)))
             # See if there's transcript page info, and update it if so
             if chunk['meta'].get('_page', 0):
                 current_transcript_page = int(chunk["meta"]['_page'])
@@ -185,7 +185,7 @@ class TranscriptIndexer(object):
                 if act.includes(timestamp):
                     break
             else:
-                print "Error: No act for timestamp %s" % seconds_to_timestamp(timestamp)
+                print("Error: No act for timestamp %s" % seconds_to_timestamp(timestamp))
                 continue
             # If we've filled up the current page, go to a new one
             if current_page_lines >= self.LINES_PER_PAGE or (last_act is not None and last_act != act):
@@ -232,11 +232,11 @@ class TranscriptIndexer(object):
             previous_log_line_id = log_line_id
             previous_timestamp = timestamp
             # Also store the text
-            text = u""
+            text = ""
             for line in chunk['lines']:
                 self.redis_conn.rpush(
                     "log_line:%s:lines" % log_line_id,
-                    u"%(speaker)s: %(text)s" % line,
+                    "%(speaker)s: %(text)s" % line,
                 )
                 text += "%s %s" % (line['speaker'], line['text'])
             # Store any images
@@ -267,7 +267,7 @@ class TranscriptIndexer(object):
             # Read the new labels into current_labels
             has_labels = False
             if '_labels' in chunk['meta']:
-                for label, endpoint in chunk['meta']['_labels'].items():
+                for label, endpoint in list(chunk['meta']['_labels'].items()):
                     if endpoint is not None and label not in current_labels:
                         current_labels[label] = endpoint
                     elif label in current_labels:
@@ -279,7 +279,7 @@ class TranscriptIndexer(object):
                         self.redis_conn.sadd("label:%s" % label, log_line_id)
                         has_labels = True
             # Expire any old labels
-            for label, endpoint in current_labels.items():
+            for label, endpoint in list(current_labels.items()):
                 if endpoint < chunk['timestamp']:
                     del current_labels[label]
             # Apply any surviving labels
@@ -288,7 +288,7 @@ class TranscriptIndexer(object):
                 has_labels = True
             # And add this logline to search index
             if has_labels:
-                print "weight = 3 for %s" % log_line_id
+                print("weight = 3 for %s" % log_line_id)
                 weight = 3.0 # magic!
             else:
                 weight = 1.0
@@ -316,9 +316,9 @@ class TranscriptIndexer(object):
             self.transcript_name
         )
         if not pages_set and current_transcript_page:
-            print "%s original pages: %d" % (
+            print("%s original pages: %d" % (
                 self.transcript_name, current_transcript_page
-            )
+            ))
             self.redis_conn.hset(
                 "pages:%s" % self.mission_name, 
                 self.transcript_name,
@@ -345,13 +345,13 @@ class MetaIndexer(object):
             self.redis_conn.set("subdomain:%s" % subdomain, meta['name'])
         del meta['subdomains']
         utc_launch_time = meta['utc_launch_time']
-        if isinstance(utc_launch_time, basestring):
+        if isinstance(utc_launch_time, str):
             # parse as something more helpful than a number
             # time.mktime operates in the local timezone, so force that to UTC first
             os.environ['TZ'] = 'UTC'
             time.tzset()
             utc_launch_time = int(time.mktime(time.strptime(utc_launch_time, "%Y-%m-%dT%H:%M:%S")))
-            print "Converted launch time to UTC timestamp:", utc_launch_time
+            print("Converted launch time to UTC timestamp:", utc_launch_time)
         is_memorial = meta.get('memorial', False)
         if is_memorial:
             default_main_transcript = None
@@ -373,7 +373,7 @@ class MetaIndexer(object):
         # TODO: Default to highest _page from transcript if we don't have this
         transcript_pages = meta.get( 'transcript_pages' )
         if transcript_pages:
-            print "Setting original pagecounts from _meta"
+            print("Setting original pagecounts from _meta")
             self.redis_conn.hmset(
                 "pages:%s" % self.mission_name,
                 transcript_pages
@@ -381,7 +381,7 @@ class MetaIndexer(object):
         
         
         copy = meta.get("copy", {})
-        for key, value in copy.items():
+        for key, value in list(copy.items()):
             copy[key] = json.dumps(value)
         if copy.get('based_on_header', None) is None:
             copy['based_on_header'] = json.dumps('Based on the original transcript')
@@ -418,7 +418,7 @@ class MetaIndexer(object):
                     "%s:%i" % (self.mission_name, i),
                 )
 
-                data['start'], data['end'] = map(mission_time_to_timestamp, data['range'])
+                data['start'], data['end'] = list(map(mission_time_to_timestamp, data['range']))
                 del data['range']
 
                 self.redis_conn.hmset(key, data)
@@ -428,7 +428,7 @@ class MetaIndexer(object):
             key = "act:%s:0" % (self.mission_name,)
             title = meta.get('copy', {}).get('title', None)
             if title is None:
-                title = meta.get('name', u'The Mission')
+                title = meta.get('name', 'The Mission')
             else:
                 title = json.loads(title)
             data = {
@@ -458,7 +458,7 @@ class MetaIndexer(object):
                 "character-ordering:%s" % self.mission_name,
                 identifier,
             )
-        for identifier, data in meta.get('characters', {}).items():
+        for identifier, data in list(meta.get('characters', {}).items()):
             mission_key   = "characters:%s" % self.mission_name
             character_key = "%s:%s" % (mission_key, identifier)
             
@@ -516,7 +516,7 @@ class MetaIndexer(object):
         glossary_terms.update(meta.get('glossary', {}))
         
         # Add all the glossary terms to redis
-        for identifier, data in glossary_terms.items():
+        for identifier, data in list(glossary_terms.items()):
             term_key = "%s:%s" % (self.mission_name, identifier.lower())
             
             # Add the ID to the list for this mission
@@ -530,16 +530,16 @@ class MetaIndexer(object):
             data['abbr'] = identifier
             data['times_mentioned'] = 0
             
-            if data.has_key('summary') and data.has_key('description'):
+            if 'summary' in data and 'description' in data:
                 data['extended_description'] = data['description']
                 data['description'] = data['summary']
                 del data['summary']
             else:
-                data['description'] = data.get('summary') or data.get('description', u"")
-            if data.has_key('description_lang'):
+                data['description'] = data.get('summary') or data.get('description', "")
+            if 'description_lang' in data:
                 data['extended_description_lang'] = data['description_lang']
                 del data['description_lang']
-            if data.has_key('summary_lang'):
+            if 'summary_lang' in data:
                 data['description_lang'] = data['summary_lang']
                 del data['summary_lang']
             
@@ -557,12 +557,12 @@ class MetaIndexer(object):
 
     def index_special_searches(self, meta):
         "Indexes things that in no way sound like 'feaster legs'."
-        for search, value in meta.get('special_searches', {}).items():
+        for search, value in list(meta.get('special_searches', {}).items()):
             self.redis_conn.set("special_search:%s:%s" % (self.mission_name, search), value)
 
     def index_errors(self, meta):
         "Indexes error page info"
-        for key, info in meta.get('error_pages', {}).items():
+        for key, info in list(meta.get('error_pages', {}).items()):
             self.redis_conn.hmset(
                 "error_page:%s:%s" % (self.mission_name, key),
                 info,
@@ -586,14 +586,14 @@ class MissionIndexer(object):
     def index_transcripts(self):
         for filename in os.listdir(self.folder_path):
             if "." not in filename and filename[0] != "_" and filename[-1] != "~":
-                print "Indexing %s..." % filename
+                print("Indexing %s..." % filename)
                 path = os.path.join(self.folder_path, filename)
                 parser = TranscriptParser(path)
                 indexer = TranscriptIndexer(self.redis_conn, self.mission_name, "%s/%s" % (self.mission_name, filename), parser)
                 indexer.index()
 
     def index_meta(self):
-        print "Indexing _meta..."
+        print("Indexing _meta...")
         path = os.path.join(self.folder_path, "_meta")
         parser = MetaParser(path)
         indexer = MetaIndexer(self.redis_conn, self.mission_name, parser)
@@ -605,12 +605,12 @@ if __name__ == "__main__":
     transcript_dir = os.path.join(os.path.dirname( __file__ ), '..', "missions")
     dirs = os.listdir(transcript_dir)
 
-    print "Reindexing into database"
+    print("Reindexing into database")
 
     for filename in dirs:
         path = os.path.join(transcript_dir, filename)
         if filename[0] not in "_." and os.path.isdir(path) and os.path.exists(os.path.join(path, "transcripts", "_meta")):
-            print "Mission: %s" % filename
+            print("Mission: %s" % filename)
             idx = MissionIndexer(redis_conn, filename, os.path.join(path, "transcripts")) 
             idx.index()
     search_db.flush()

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -146,7 +146,7 @@ class TranscriptIndexer(object):
                 doc.fields.append(xappy.Field("speaker", line['speaker']))
         doc.id = id
         try:
-            search_db.add(doc)
+            search_db.replace(doc)
         except xappy.errors.IndexerError:
             print("umm, error")
             print(id, lines)

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -16,7 +16,7 @@ class TranscriptParser(object):
         self.path = path
 
     def get_lines(self, offset):
-        with open(self.path) as fh:
+        with open(self.path, encoding="utf-8") as fh:
             fh.seek(offset)
             for line in fh:
                 yield line
@@ -126,7 +126,7 @@ class MetaParser(TranscriptParser):
     
     def get_meta(self):
         try:
-            with open(self.path) as fh:
+            with open(self.path, encoding="utf-8") as fh:
                 return json.load(fh)
         except ValueError as e:
             raise ValueError("JSON decode error in file %s: %s" % (self.path, e))

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -40,7 +40,7 @@ class TranscriptParser(object):
                 except StopIteration:
                     break
                 offset += len(line)
-                line = line.decode("utf8")
+                line = line
             # If it's a comment or empty line, ignore it.
             if not line.strip() or line.strip()[0] == "#":
                 continue
@@ -74,7 +74,7 @@ class TranscriptParser(object):
                     except StopIteration:
                         break
                     offset += len(line)
-                    line = line.decode("utf8")
+                    line = line
                     if not line.strip() or line.strip()[0] == "#":
                         continue
                     if line[0] in string.whitespace:

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 import string
 try:
     import json
@@ -36,7 +36,7 @@ class TranscriptParser(object):
                 reuse_line = None
             else:
                 try:
-                    line = lines.next()
+                    line = next(lines)
                 except StopIteration:
                     break
                 offset += len(line)
@@ -53,7 +53,7 @@ class TranscriptParser(object):
                     try:
                         timestamp = timestamp_to_seconds(line[1:].split("]")[0])
                     except ValueError:
-                        print "Error: invalid timestamp %s" % (line[1:], )
+                        print("Error: invalid timestamp %s" % (line[1:], ))
                         raise
                 if current_chunk:
                     yield current_chunk
@@ -70,7 +70,7 @@ class TranscriptParser(object):
                 name, blob = line.split(":", 1)
                 while True:
                     try:
-                        line = lines.next()
+                        line = next(lines)
                     except StopIteration:
                         break
                     offset += len(line)
@@ -91,18 +91,18 @@ class TranscriptParser(object):
                         try:
                             data = json.loads('"%s"' % blob.replace('"', r'\"'))
                         except ValueError:
-                            print "Error: Invalid json at timestamp %s, key %s" % \
-                                            (seconds_to_timestamp(timestamp), name)
+                            print("Error: Invalid json at timestamp %s, key %s" % \
+                                            (seconds_to_timestamp(timestamp), name))
                             continue
                     current_chunk['meta'][name.strip()] = data
             # If it's a continuation, append to the current line
             elif line[0] in string.whitespace:
                 # Continuation line
                 if not current_chunk:
-                    print "Error: Continuation line before first timestamp header. Line: %s" % \
-                                                                        (line)
+                    print("Error: Continuation line before first timestamp header. Line: %s" % \
+                                                                        (line))
                 elif not current_chunk['lines']:
-                    print "Error: Continuation line before first speaker name."
+                    print("Error: Continuation line before first speaker name.")
                 else:
                     current_chunk['lines'][-1]['text'] += " " + line.strip()
             # If it's a new line, start a new line. Shock.
@@ -111,7 +111,7 @@ class TranscriptParser(object):
                 try:
                     speaker, text = line.split(":", 1)
                 except ValueError:
-                    print "Error: First speaker line not in Name: Text format: %s." % (line,)
+                    print("Error: First speaker line not in Name: Text format: %s." % (line,))
                 else:
                     line = {
                         "speaker": speaker.strip(),
@@ -128,6 +128,6 @@ class MetaParser(TranscriptParser):
         try:
             with open(self.path) as fh:
                 return json.load(fh)
-        except ValueError, e:
+        except ValueError as e:
             raise ValueError("JSON decode error in file %s: %s" % (self.path, e))
         return json.load(fh)

--- a/backend/reformat.py
+++ b/backend/reformat.py
@@ -12,15 +12,15 @@ def reformat(filename):
     for chunk in parser.get_chunks():
         timestamp = seconds_to_timestamp(chunk['timestamp'])
         for line in chunk['lines']:
-            print "%s\t%s:\t %s" % (
+            print("%s\t%s:\t %s" % (
                 timestamp,
                 line['speaker'],
                 line['text'],
-            )
+            ))
 
 if __name__ == "__main__":
     try:
         reformat(sys.argv[1])
     except IndexError:
-        print "Please pass a file to reformat"
+        print("Please pass a file to reformat")
 

--- a/backend/stats_porn.py
+++ b/backend/stats_porn.py
@@ -135,7 +135,10 @@ class StatsPornGenerator(object):
 
 
 if __name__ == "__main__":
-    redis_conn = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379"))
+    redis_conn = redis.from_url(
+        os.environ.get("REDIS_URL", "redis://localhost:6379"),
+        decode_responses=True
+    )
 
     generator = StatsPornGenerator(redis_conn)
     generator.build_all_missions()

--- a/backend/stats_porn.py
+++ b/backend/stats_porn.py
@@ -1,9 +1,8 @@
 import subprocess
-import redis
 import os
 
 from backend.api import Mission, Act, LogLine
-from backend.util import seconds_to_timestamp
+from backend.util import redis_connection, seconds_to_timestamp
 
 
 class StatsPornGenerator(object):
@@ -135,10 +134,5 @@ class StatsPornGenerator(object):
 
 
 if __name__ == "__main__":
-    redis_conn = redis.from_url(
-        os.environ.get("REDIS_URL", "redis://localhost:6379"),
-        decode_responses=True
-    )
-
-    generator = StatsPornGenerator(redis_conn)
+    generator = StatsPornGenerator(redis_connection)
     generator.build_all_missions()

--- a/backend/stats_porn.py
+++ b/backend/stats_porn.py
@@ -25,9 +25,9 @@ class StatsPornGenerator(object):
             self.build_mission(mission)
 
     def build_mission(self, mission):
-        print "Building data visualisations for %s..." % mission.name
+        print("Building data visualisations for %s..." % mission.name)
         for act in list(Act.Query(self.redis_conn, mission.name)):
-            print ' ... %s' % act.title
+            print(' ... %s' % act.title)
 
             # Split the act into sections, one for each bar on the graph
             act_duration = act.end - act.start
@@ -100,7 +100,7 @@ class StatsPornGenerator(object):
 
             # Iterate over the key scenes adding them to the graph and image map
             for i, key_scene in enumerate(act.key_scenes()):
-                print '     - %s' % key_scene.title
+                print('     - %s' % key_scene.title)
 
                 top_left_x =     int((self.graph_background_width / float(act_duration)) * (key_scene.start - act.start)) + 2
                 top_left_y =     self.max_bar_height + 5 + 14

--- a/backend/stats_porn.py
+++ b/backend/stats_porn.py
@@ -118,7 +118,7 @@ class StatsPornGenerator(object):
 
                 image_map.append('<area shape="rect" coords="%(coords)s" href="%(url)s" alt="%(alt)s">' % {
                     "url":      '/%s/%s/#show-selection' % (seconds_to_timestamp(key_scene.start), seconds_to_timestamp(key_scene.end)),
-                    "alt":      key_scene.title.decode('utf-8'),
+                    "alt":      key_scene.title,
                     "coords":   '%s,%s,%s,%s' % (top_left_x, top_left_y, bottom_right_x, bottom_right_y),
                 })
 

--- a/backend/util.py
+++ b/backend/util.py
@@ -19,6 +19,6 @@ def timestamp_to_seconds(timestamp):
         mult = -1
     else:
         mult = 1
-    parts = map(floor_and_int, timestamp.split(":", 3))
+    parts = list(map(floor_and_int, timestamp.split(":", 3)))
     return mult * ((parts[0] * 86400) + (parts[1] * 3600) + (parts[2] * 60) + parts[3])
 

--- a/backend/util.py
+++ b/backend/util.py
@@ -1,4 +1,6 @@
 import math
+import os
+import redis
 
 def seconds_to_timestamp(seconds):
     abss = abs(seconds)
@@ -22,3 +24,7 @@ def timestamp_to_seconds(timestamp):
     parts = list(map(floor_and_int, timestamp.split(":", 3)))
     return mult * ((parts[0] * 86400) + (parts[1] * 3600) + (parts[2] * 60) + parts[3])
 
+redis_connection = redis.from_url(
+    os.environ.get("REDIS_URL", "redis://localhost:6379"),
+    decode_responses=True
+)

--- a/ext/xappy-0.5-sja-1/xappy/__init__.py
+++ b/ext/xappy-0.5-sja-1/xappy/__init__.py
@@ -26,10 +26,10 @@ __docformat__ = "restructuredtext en"
 
 __version__ = '0.5'
 
-import _checkxapian
-from datastructures import Field, UnprocessedDocument, ProcessedDocument
-from errors import *
-from fieldactions import FieldActions
-from indexerconnection import IndexerConnection
-from searchconnection import SearchConnection
-from replaylog import set_replay_path
+from . import _checkxapian
+from .datastructures import Field, UnprocessedDocument, ProcessedDocument
+from .errors import *
+from .fieldactions import FieldActions
+from .indexerconnection import IndexerConnection
+from .searchconnection import SearchConnection
+from .replaylog import set_replay_path

--- a/ext/xappy-0.5-sja-1/xappy/datastructures.py
+++ b/ext/xappy-0.5-sja-1/xappy/datastructures.py
@@ -20,10 +20,10 @@ r"""datastructures.py: Datastructures for search engine core.
 """
 __docformat__ = "restructuredtext en"
 
-import errors
-from replaylog import log
+from . import errors
+from .replaylog import log
 import xapian
-import cPickle
+import pickle
 
 class Field(object):
     # Use __slots__ because we're going to have very many Field objects in
@@ -182,7 +182,7 @@ class ProcessedDocument(object):
 
         """
         if self._data is not None:
-            self._doc.set_data(cPickle.dumps(self._data, 2))
+            self._doc.set_data(pickle.dumps(self._data, 2))
             self._data = None
         return self._doc
 
@@ -192,7 +192,7 @@ class ProcessedDocument(object):
             if rawdata == '':
                 self._data = {}
             else:
-                self._data = cPickle.loads(rawdata)
+                self._data = pickle.loads(rawdata)
         return self._data
     def _set_data(self, data):
         if not isinstance(data, dict):

--- a/ext/xappy-0.5-sja-1/xappy/datastructures.py
+++ b/ext/xappy-0.5-sja-1/xappy/datastructures.py
@@ -188,8 +188,8 @@ class ProcessedDocument(object):
 
     def _get_data(self):
         if self._data is None:
-            rawdata = self._doc.get_data().decode()
-            if rawdata == '':
+            rawdata = self._doc.get_data()
+            if rawdata == b'':
                 self._data = {}
             else:
                 self._data = pickle.loads(rawdata)
@@ -209,7 +209,7 @@ class ProcessedDocument(object):
     def _get_id(self):
         tl = self._doc.termlist()
         try:
-            term = tl.skip_to('Q').term
+            term = tl.skip_to('Q').term.decode()
             if len(term) == 0 or term[0] != 'Q':
                 return None
         except StopIteration:

--- a/ext/xappy-0.5-sja-1/xappy/datastructures.py
+++ b/ext/xappy-0.5-sja-1/xappy/datastructures.py
@@ -188,7 +188,7 @@ class ProcessedDocument(object):
 
     def _get_data(self):
         if self._data is None:
-            rawdata = self._doc.get_data()
+            rawdata = self._doc.get_data().decode()
             if rawdata == '':
                 self._data = {}
             else:

--- a/ext/xappy-0.5-sja-1/xappy/fieldactions.py
+++ b/ext/xappy-0.5-sja-1/xappy/fieldactions.py
@@ -20,12 +20,12 @@ r"""fieldactions.py: Definitions and implementations of field actions.
 """
 __docformat__ = "restructuredtext en"
 
-import _checkxapian
-import errors
-import marshall
-from replaylog import log
+from . import _checkxapian
+from . import errors
+from . import marshall
+from .replaylog import log
 import xapian
-import parsedate
+from . import parsedate
 
 def _act_store_content(fieldname, doc, value, context):
     """Perform the STORE_CONTENT action.
@@ -153,7 +153,7 @@ class SortableMarshaller(object):
         """
         try:
             value = parsedate.date_from_string(value)
-        except ValueError, e:
+        except ValueError as e:
             raise self._err("Value supplied to field %r must be a "
                             "valid date: was %r: error is '%s'" %
                             (fieldname, value, str(e)))
@@ -320,7 +320,7 @@ class FieldActions(object):
         info = self._action_info[action]
 
         # Check parameter names
-        for key in kwargs.keys():
+        for key in list(kwargs.keys()):
             if key not in info[1]:
                 raise errors.IndexerError("Unknown parameter name for action %r: %r" % (info[0], key))
 
@@ -378,7 +378,7 @@ class FieldActions(object):
             field_mappings.add_prefix(self._fieldname)
         if 'slot' in info[3]:
             purposes = info[3]['slot']
-            if isinstance(purposes, basestring):
+            if isinstance(purposes, str):
                 field_mappings.add_slot(self._fieldname, purposes)
             else:
                 slotnum = None
@@ -409,7 +409,7 @@ class FieldActions(object):
         - `context` is an ActionContext object used to keep state in.
 
         """
-        for type, actionlist in self._actions.iteritems():
+        for type, actionlist in self._actions.items():
             info = self._action_info[type]            
             for kwargs in actionlist:
                 info[2](self._fieldname, doc, value, context, **kwargs)

--- a/ext/xappy-0.5-sja-1/xappy/fieldmappings.py
+++ b/ext/xappy-0.5-sja-1/xappy/fieldmappings.py
@@ -20,7 +20,7 @@ r"""fieldmappings.py: Mappings from field names to term prefixes, etc.
 """
 __docformat__ = "restructuredtext en"
 
-import cPickle as _cPickle
+import pickle as _cPickle
 
 class FieldMappings(object):
     """Mappings from field names to term prefixes, slot values, etc.
@@ -82,7 +82,7 @@ class FieldMappings(object):
         If the prefix is not found, return None.
 
         """
-        for key, val in self._prefixes.iteritems():
+        for key, val in self._prefixes.items():
             if val == prefix:
                 return key
         return None

--- a/ext/xappy-0.5-sja-1/xappy/highlight.py
+++ b/ext/xappy-0.5-sja-1/xappy/highlight.py
@@ -102,11 +102,12 @@ class Highlighter(object):
         900
 
         """
-        for p in range(len(term)):
-            if not term[p].isupper():
-                return term[p:]
-            elif term[p] == 'R':
-                return term[p+1:]
+        decoded_term = term.decode()
+        for p in range(len(decoded_term)):
+            if not decoded_term[p].isupper():
+                return decoded_term[p:]
+            elif decoded_term[p] == 'R':
+                return decoded_term[p+1:]
         return ''
 
     def _query_to_stemmed_words(self, query):

--- a/ext/xappy-0.5-sja-1/xappy/highlight.py
+++ b/ext/xappy-0.5-sja-1/xappy/highlight.py
@@ -68,7 +68,7 @@ class Highlighter(object):
         Returns a list of utf-8 encoded simple strings.
 
         """
-        if isinstance(text, unicode):
+        if isinstance(text, str):
             text = text.encode('utf-8')
 
         words = self._split_re.findall(text)
@@ -102,7 +102,7 @@ class Highlighter(object):
         900
 
         """
-        for p in xrange(len(term)):
+        for p in range(len(term)):
             if not term[p].isupper():
                 return term[p:]
             elif term[p] == 'R':
@@ -171,7 +171,7 @@ class Highlighter(object):
 
         # select high-scoring blocks first, down to zero-scoring
         chars = 0
-        for count in xrange(3, -1, -1):
+        for count in range(3, -1, -1):
             for b in blocks:
                 if b[3] >= count:
                     if not strict_length or chars == 0 or chars + b[2] < maxlen:
@@ -195,7 +195,7 @@ class Highlighter(object):
 
         # trim down to maxlen
         l = 0
-        for i in xrange (len (words2)):
+        for i in range (len (words2)):
             if words2[i] != ellipsis:
                 l += len (words2[i])
             if l >= maxlen:

--- a/ext/xappy-0.5-sja-1/xappy/highlight.py
+++ b/ext/xappy-0.5-sja-1/xappy/highlight.py
@@ -69,7 +69,7 @@ class Highlighter(object):
 
         """
         if isinstance(text, str):
-            text = text.encode('utf-8')
+            text = text
 
         words = self._split_re.findall(text)
         if strip_tags:

--- a/ext/xappy-0.5-sja-1/xappy/marshall.py
+++ b/ext/xappy-0.5-sja-1/xappy/marshall.py
@@ -22,7 +22,7 @@ __docformat__ = "restructuredtext en"
 
 import math
 import xapian
-from replaylog import log as _log
+from .replaylog import log as _log
 
 def float_to_string(value):
     """Marshall a floating point number to a string which sorts in the

--- a/ext/xappy-0.5-sja-1/xappy/replaylog.py
+++ b/ext/xappy-0.5-sja-1/xappy/replaylog.py
@@ -22,7 +22,7 @@ __docformat__ = "restructuredtext en"
 
 import datetime
 import sys
-import thread
+import _thread
 import threading
 import time
 import traceback
@@ -85,7 +85,7 @@ class ReplayLog(object):
             for membername in dir(item):
                 member = getattr(item, membername)
                 if isinstance(member, types.MethodType):
-                    self._xapian_methods[member.im_func] = (name, membername)
+                    self._xapian_methods[member.__func__] = (name, membername)
                     has_members = True
             if has_members:
                 self._xapian_classes[item] = name
@@ -129,7 +129,7 @@ class ReplayLog(object):
         if classname is not None:
             return True
         # Check for subclasses of xapian classes.
-        for classobj, classname in self._xapian_classes.iteritems():
+        for classobj, classname in self._xapian_classes.items():
             if isinstance(obj, classobj):
                 return True
         # Not a xapian class or subclass.
@@ -142,12 +142,12 @@ class ReplayLog(object):
 
         """
         # Check if it's a xapian class, or subclass.
-        if isinstance(obj, types.TypeType):
+        if isinstance(obj, type):
             classname = self._xapian_classes.get(obj, None)
             if classname is not None:
                 return classname
 
-            for classobj, classname in self._xapian_classes.iteritems():
+            for classobj, classname in self._xapian_classes.items():
                 if issubclass(obj, classobj):
                     return "subclassof_%s" % (classname, )
 
@@ -168,14 +168,14 @@ class ReplayLog(object):
 
         # Check if it's a proxied method.
         if isinstance(obj, LoggedProxyMethod):
-            classname, methodname = self._xapian_methods[obj.real.im_func]
+            classname, methodname = self._xapian_methods[obj.real.__func__]
             objnum = self._get_obj_num(obj.proxyobj, maybe_new=maybe_new)
             return "%s#%d.%s" % (classname, objnum, methodname)
 
         # Check if it's a subclass of a xapian class.  Note: this will only
         # pick up subclasses, because the original classes are filtered out
         # higher up.
-        for classobj, classname in self._xapian_classes.iteritems():
+        for classobj, classname in self._xapian_classes.items():
             if isinstance(obj, classobj):
                 objnum = self._get_obj_num(obj, maybe_new=maybe_new)
                 return "subclassof_%s#%d" % (classname, objnum)
@@ -205,18 +205,18 @@ class ReplayLog(object):
         if xapargname is not None:
             return xapargname
 
-        if isinstance(arg, basestring):
-            if isinstance(arg, unicode):
+        if isinstance(arg, str):
+            if isinstance(arg, str):
                 arg = arg.encode('utf-8')
             return 'str(%d,%s)' % (len(arg), arg)
 
-        if isinstance(arg, long):
+        if isinstance(arg, int):
             try:
                 arg = int(arg)
             except OverFlowError:
                 pass
 
-        if isinstance(arg, long):
+        if isinstance(arg, int):
             return 'long(%d)' % arg
 
         if isinstance(arg, int):
@@ -256,7 +256,7 @@ class ReplayLog(object):
         call_num = self._next_call
         self._next_call += 1
 
-        thread_id = thread.get_ident()
+        thread_id = _thread.get_ident()
         try:
             thread_num = self._thread_ids[thread_id]
         except KeyError:
@@ -289,11 +289,11 @@ class ReplayLog(object):
             self._log("CALL%s:UNKNOWN:%r(%s)\n" % (call_id, call, logargs))
         return call_id
 
-    def log_except(self, (etype, value, tb), call_id):
+    def log_except(self, xxx_todo_changeme, call_id):
         """Log an exception which has occurred.
 
         """
-        # No access to an members, so no need to acquire mutex.
+        (etype, value, tb) = xxx_todo_changeme
         exc = traceback.format_exception_only(etype, value)
         self._log("EXCEPT%s:%s\n" % (call_id, ''.join(exc).strip()))
 

--- a/ext/xappy-0.5-sja-1/xappy/replaylog.py
+++ b/ext/xappy-0.5-sja-1/xappy/replaylog.py
@@ -207,7 +207,7 @@ class ReplayLog(object):
 
         if isinstance(arg, str):
             if isinstance(arg, str):
-                arg = arg.encode('utf-8')
+                arg = arg
             return 'str(%d,%s)' % (len(arg), arg)
 
         if isinstance(arg, int):

--- a/ext/xappy-0.5-sja-1/xappy/schema.py
+++ b/ext/xappy-0.5-sja-1/xappy/schema.py
@@ -20,9 +20,9 @@ r"""schema.py: xdefinitions and implementations of field actions.
 """
 __docformat__ = "restructuredtext en"
 
-import errors as _errors
-from replaylog import log as _log
-import parsedate as _parsedate
+from . import errors as _errors
+from .replaylog import log as _log
+from . import parsedate as _parsedate
 
 class Schema(object):
     def __init__(self):

--- a/ext/xappy-0.5-sja-1/xappy/searchconnection.py
+++ b/ext/xappy-0.5-sja-1/xappy/searchconnection.py
@@ -20,20 +20,20 @@ r"""searchconnection.py: A connection to the search engine for searching.
 """
 __docformat__ = "restructuredtext en"
 
-import _checkxapian
+from . import _checkxapian
 import os as _os
-import cPickle as _cPickle
+import pickle as _cPickle
 import math
 
 import xapian as _xapian
-from datastructures import *
-from fieldactions import *
-import fieldmappings as _fieldmappings
-import highlight as _highlight 
-import errors as _errors
-import indexerconnection as _indexerconnection
+from .datastructures import *
+from .fieldactions import *
+from . import fieldmappings as _fieldmappings
+from . import highlight as _highlight 
+from . import errors as _errors
+from . import indexerconnection as _indexerconnection
 import re as _re
-from replaylog import log as _log
+from .replaylog import log as _log
 
 class SearchResult(ProcessedDocument):
     """A result from a search.
@@ -77,7 +77,7 @@ class SearchResult(ProcessedDocument):
 
         """
         actions = self._results._conn._field_actions[field]._actions
-        for action, kwargslist in actions.iteritems():
+        for action, kwargslist in actions.items():
             if action == FieldActions.INDEX_FREETEXT:
                 for kwargs in kwargslist:
                     try:
@@ -180,11 +180,11 @@ class SearchResultIter(object):
         else:
             self._iter = iter(self._order)
 
-    def next(self):
+    def __next__(self):
         if self._order is None:
-            msetitem = self._iter.next()
+            msetitem = next(self._iter)
         else:
-            index = self._iter.next()
+            index = next(self._iter)
             msetitem = self._results._mset.get_hit(index)
         return SearchResult(msetitem, self._results)
 
@@ -309,8 +309,8 @@ class SearchResults(object):
         tophits = []
         nottophits = []
 
-        clusterstarts = dict(((c[0], None) for c in clusters.itervalues()))
-        for i in xrange(self.endrank):
+        clusterstarts = dict(((c[0], None) for c in clusters.values()))
+        for i in range(self.endrank):
             if i in clusterstarts:
                 tophits.append(i)
             else:
@@ -324,14 +324,14 @@ class SearchResults(object):
 
         """
         prefixes = {}
-        if isinstance(fields, basestring):
+        if isinstance(fields, str):
             fields = [fields]
         for field in fields:
             try:
                 actions = self._conn._field_actions[field]._actions
             except KeyError:
                 continue
-            for action, kwargslist in actions.iteritems():
+            for action, kwargslist in actions.items():
                 if action == FieldActions.INDEX_FREETEXT:
                     prefix = self._conn._field_mappings.get_prefix(field)
                     prefixes[prefix] = None
@@ -341,7 +341,7 @@ class SearchResults(object):
                               FieldActions.FACET,):
                     prefix = self._conn._field_mappings.get_prefix(field)
                     prefixes[prefix] = None
-        prefix_re = _re.compile('|'.join([_re.escape(x) + '[^A-Z]' for x in prefixes.keys()]))
+        prefix_re = _re.compile('|'.join([_re.escape(x) + '[^A-Z]' for x in list(prefixes.keys())]))
         class decider(_xapian.ExpandDecider):
             def __call__(self, term):
                 return prefix_re.match(term) is not None
@@ -377,7 +377,7 @@ class SearchResults(object):
         sim_count = 0
         new_order = []
         end = min(self.endrank, maxcount)
-        for i in xrange(end):
+        for i in range(end):
             if full:
                 new_order.append(i)
                 continue
@@ -414,12 +414,12 @@ class SearchResults(object):
             for hit in nottophits:
                 new_order.append(hit.rank)
         if end != self.endrank:
-            new_order.extend(range(end, self.endrank))
+            new_order.extend(list(range(end, self.endrank)))
         assert len(new_order) == self.endrank
         if reordered:
             self._mset_order = new_order
         else:
-            assert new_order == range(self.endrank)
+            assert new_order == list(range(self.endrank))
 
     def __repr__(self):
         return ("<SearchResults(startrank=%d, "
@@ -620,7 +620,7 @@ class SearchResults(object):
             raise errors.SearchError("Facets unsupported with this release of xapian")
         if self._facetspy is None:
             raise _errors.SearchError("Facet selection wasn't enabled when the search was run")
-        if isinstance(required_facets, basestring):
+        if isinstance(required_facets, str):
             required_facets = [required_facets]
         scores = []
         facettypes = {}
@@ -688,7 +688,7 @@ class SearchResults(object):
             if facettypes[field] == 'float':
                 # Convert numbers to python numbers, and number ranges to a
                 # python tuple of two numbers.
-                for value, frequency in values.iteritems():
+                for value, frequency in values.items():
                     if len(value) <= 9:
                         value1 = _log(_xapian.sortable_unserialise, value)
                         value2 = value1
@@ -697,7 +697,7 @@ class SearchResults(object):
                         value2 = _log(_xapian.sortable_unserialise, value[9:])
                     newvalues.append(((value1, value2), frequency))
             else:
-                for value, frequency in values.iteritems():
+                for value, frequency in values.items():
                     newvalues.append((value, frequency))
 
             newvalues.sort()
@@ -792,7 +792,7 @@ class SearchConnection(object):
             actions = self._field_actions[field]._actions
         except KeyError:
             actions = {}
-        for action, kwargslist in actions.iteritems():
+        for action, kwargslist in actions.items():
             if action == FieldActions.SORT_AND_COLLAPSE:
                 for kwargs in kwargslist:
                     return kwargs['type']
@@ -871,9 +871,9 @@ class SearchConnection(object):
         for handler, userdata in self._close_handlers:
             try:
                 handler(indexpath, userdata)
-            except Exception, e:
+            except Exception as e:
                 import sys, traceback
-                print >>sys.stderr, "WARNING: unhandled exception in handler called by SearchConnection.close(): %s" % traceback.format_exception_only(type(e), e)
+                print("WARNING: unhandled exception in handler called by SearchConnection.close(): %s" % traceback.format_exception_only(type(e), e), file=sys.stderr)
 
     def get_doccount(self):
         """Count the number of documents in the database.
@@ -1033,7 +1033,7 @@ class SearchConnection(object):
         except KeyError:
             actions = {}
         facettype = None
-        for action, kwargslist in actions.iteritems():
+        for action, kwargslist in actions.items():
             if action == FieldActions.FACET:
                 for kwargs in kwargslist:
                     facettype = kwargs.get('type', None)
@@ -1043,7 +1043,7 @@ class SearchConnection(object):
                 break
 
         if facettype == 'float':
-            if isinstance(val, basestring):
+            if isinstance(val, str):
                 val = [float(v) for v in val.split(',', 2)]
             assert(len(val) == 2)
             try:
@@ -1072,9 +1072,9 @@ class SearchConnection(object):
         if self._index is None:
             raise _errors.SearchError("SearchConnection has been closed")
 
-        if isinstance(allow, basestring):
+        if isinstance(allow, str):
             allow = (allow, )
-        if isinstance(deny, basestring):
+        if isinstance(deny, str):
             deny = (deny, )
         if allow is not None and len(allow) == 0:
             allow = None
@@ -1084,9 +1084,9 @@ class SearchConnection(object):
             raise _errors.SearchError("Cannot specify both `allow` and `deny` "
                                       "(got %r and %r)" % (allow, deny))
 
-        if isinstance(default_allow, basestring):
+        if isinstance(default_allow, str):
             default_allow = (default_allow, )
-        if isinstance(default_deny, basestring):
+        if isinstance(default_deny, str):
             default_deny = (default_deny, )
         if default_allow is not None and len(default_allow) == 0:
             default_allow = None
@@ -1110,7 +1110,7 @@ class SearchConnection(object):
                 actions = self._field_actions[field]._actions
             except KeyError:
                 actions = {}
-            for action, kwargslist in actions.iteritems():
+            for action, kwargslist in actions.items():
                 if action == FieldActions.INDEX_EXACT:
                     # FIXME - need patched version of xapian to add exact prefixes
                     #qp.add_exact_prefix(field, self._field_mappings.get_prefix(field))
@@ -1142,7 +1142,7 @@ class SearchConnection(object):
                     actions = self._field_actions[field]._actions
                 except KeyError:
                     actions = {}
-                for action, kwargslist in actions.iteritems():
+                for action, kwargslist in actions.items():
                     if action == FieldActions.INDEX_FREETEXT:
                         qp.add_prefix('', self._field_mappings.get_prefix(field))
                         # FIXME - set stemming options for the default prefix
@@ -1172,7 +1172,7 @@ class SearchConnection(object):
                                                self._qp_flags_synonym |
                                                self._qp_flags_bool,
                                                prefix)
-        except _xapian.QueryParserError, e:
+        except _xapian.QueryParserError as e:
             # If we got a parse error, retry without boolean operators (since
             # these are the usual cause of the parse error).
             q1 = self._query_parse_with_prefix(qp, string,
@@ -1187,7 +1187,7 @@ class SearchConnection(object):
                                                self._qp_flags_base |
                                                self._qp_flags_bool,
                                                prefix)
-        except _xapian.QueryParserError, e:
+        except _xapian.QueryParserError as e:
             # If we got a parse error, retry without boolean operators (since
             # these are the usual cause of the parse error).
             q2 = self._query_parse_with_prefix(qp, string,
@@ -1263,7 +1263,7 @@ class SearchConnection(object):
             actions = {}
 
         # need to check on field type, and stem / split as appropriate
-        for action, kwargslist in actions.iteritems():
+        for action, kwargslist in actions.items():
             if action in (FieldActions.INDEX_EXACT,
                           FieldActions.TAG,
                           FieldActions.FACET,):
@@ -1376,11 +1376,11 @@ class SearchConnection(object):
         if allow is not None and deny is not None:
             raise _errors.SearchError("Cannot specify both `allow` and `deny`")
 
-        if isinstance(ids, basestring):
+        if isinstance(ids, str):
             ids = (ids, )
-        if isinstance(allow, basestring):
+        if isinstance(allow, str):
             allow = (allow, )
-        if isinstance(deny, basestring):
+        if isinstance(deny, str):
             deny = (deny, )
 
         # Set "allow" to contain a list of all the fields to use.
@@ -1396,7 +1396,7 @@ class SearchConnection(object):
                 actions = self._field_actions[field]._actions
             except KeyError:
                 actions = {}
-            for action, kwargslist in actions.iteritems():
+            for action, kwargslist in actions.items():
                 if action == FieldActions.INDEX_FREETEXT:
                     prefixes[self._field_mappings.get_prefix(field)] = field
 
@@ -1405,7 +1405,7 @@ class SearchConnection(object):
             try:
                 eterms = self._perform_expand(ids, prefixes, simterms, weight)
                 break;
-            except _xapian.DatabaseModifiedError, e:
+            except _xapian.DatabaseModifiedError as e:
                 self.reopen()
         return eterms, prefixes
 
@@ -1443,7 +1443,7 @@ class SearchConnection(object):
         for id in ids:
             pl = self._index.postlist('Q' + id)
             try:
-                xapid = pl.next()
+                xapid = next(pl)
                 rset.add_document(xapid.docid)
             except StopIteration:
                 pass
@@ -1512,7 +1512,7 @@ class SearchConnection(object):
                            qp.FLAG_SPELLING_CORRECTION)
         corrected = qp.get_corrected_query_string()
         if len(corrected) == 0:
-            if isinstance(querystr, unicode):
+            if isinstance(querystr, str):
                 # Encode as UTF-8 for consistency - this happens automatically
                 # to values passed to Xapian.
                 return querystr.encode('utf-8')
@@ -1550,7 +1550,7 @@ class SearchConnection(object):
         ends a prefix, even if followed by capital letters.
         
         """
-        for p in xrange(len(term)):
+        for p in range(len(term)):
             if term[p].islower():
                 return term[:p]
             elif term[p] == 'R':
@@ -1684,7 +1684,7 @@ class SearchConnection(object):
         matchspies = []
 
         # First, add a matchspy for any gettags fields
-        if isinstance(gettags, basestring):
+        if isinstance(gettags, str):
             if len(gettags) != 0:
                 gettags = [gettags]
         tagspy = None
@@ -1723,14 +1723,14 @@ class SearchConnection(object):
                     field = self._field_mappings.get_fieldname_from_prefix(prefix)
                     if field and FieldActions.FACET in self._field_actions[field]._actions:
                         queryfacets.add(field)
-                    termsiter.next()
+                    next(termsiter)
 
             for field in allowfacets:
                 try:
                     actions = self._field_actions[field]._actions
                 except KeyError:
                     actions = {}
-                for action, kwargslist in actions.iteritems():
+                for action, kwargslist in actions.items():
                     if action == FieldActions.FACET:
                         # filter out non-top-level facets that aren't subfacets
                         # of a facet in the query
@@ -1792,7 +1792,7 @@ class SearchConnection(object):
                     mset = enq.get_mset(startrank, maxitems, checkatleast,
                                         None, None, matchspy)
                 break
-            except _xapian.DatabaseModifiedError, e:
+            except _xapian.DatabaseModifiedError as e:
                 self.reopen()
         facet_hierarchy = None
         if usesubfacets:
@@ -1833,12 +1833,12 @@ class SearchConnection(object):
             try:
                 postlist = self._index.postlist('Q' + id)
                 try:
-                    plitem = postlist.next()
+                    plitem = next(postlist)
                 except StopIteration:
                     # Unique ID not found
                     raise KeyError('Unique ID %r not found' % id)
                 try:
-                    postlist.next()
+                    next(postlist)
                     raise _errors.IndexerError("Multiple documents " #pragma: no cover
                                                "found with same unique ID")
                 except StopIteration:
@@ -1849,7 +1849,7 @@ class SearchConnection(object):
                 result.id = id
                 result._doc = self._index.get_document(plitem.docid)
                 return result
-            except _xapian.DatabaseModifiedError, e:
+            except _xapian.DatabaseModifiedError as e:
                 self.reopen()
 
     def iter_synonyms(self, prefix=""):

--- a/ext/xappy-0.5-sja-1/xappy/searchconnection.py
+++ b/ext/xappy-0.5-sja-1/xappy/searchconnection.py
@@ -1515,7 +1515,7 @@ class SearchConnection(object):
             if isinstance(querystr, str):
                 # Encode as UTF-8 for consistency - this happens automatically
                 # to values passed to Xapian.
-                return querystr.encode('utf-8')
+                return querystr
             return querystr
         return corrected
 

--- a/global/apps/homepage/middleware.py
+++ b/global/apps/homepage/middleware.py
@@ -6,4 +6,7 @@ class RedisMiddleware(object):
     Add a redis object to every request
     """
     def process_request(self, request):
-        request.redis_conn = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379"))
+        request.redis_conn = redis.from_url(
+            os.environ.get("REDIS_URL", "redis://localhost:6379"),
+            decode_responses=True
+        )

--- a/global/apps/homepage/middleware.py
+++ b/global/apps/homepage/middleware.py
@@ -1,12 +1,8 @@
-import os
-import redis
+from backend.util import redis_connection
 
 class RedisMiddleware(object):
     """
     Add a redis object to every request
     """
     def process_request(self, request):
-        request.redis_conn = redis.from_url(
-            os.environ.get("REDIS_URL", "redis://localhost:6379"),
-            decode_responses=True
-        )
+        request.redis_conn = redis_connection

--- a/global/apps/homepage/templatetags/missions.py
+++ b/global/apps/homepage/templatetags/missions.py
@@ -11,10 +11,10 @@ def featured(missions, featured=True):
 
 @register.filter
 def mission_url(mission):
-    if isinstance(mission, basestring):
-        return u"//%s.%s/" % (mission, settings.PROJECT_DOMAIN)
+    if isinstance(mission, str):
+        return "//%s.%s/" % (mission, settings.PROJECT_DOMAIN)
     else:
         if mission.subdomain is not None:
-            return u"//%s.%s/" % (mission.subdomain, settings.PROJECT_DOMAIN)
+            return "//%s.%s/" % (mission.subdomain, settings.PROJECT_DOMAIN)
         else:
-            return u"//%s.%s/" % (mission.name, settings.PROJECT_DOMAIN)
+            return "//%s.%s/" % (mission.name, settings.PROJECT_DOMAIN)

--- a/global/apps/homepage/views.py
+++ b/global/apps/homepage/views.py
@@ -2,7 +2,7 @@
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.views.decorators.cache import cache_control
-from urllib import quote
+from urllib.parse import quote
 import random
 from backend.api import Mission
 

--- a/global/apps/search/views.py
+++ b/global/apps/search/views.py
@@ -1,5 +1,5 @@
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from django.views.generic import TemplateView
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -72,7 +72,7 @@ class SearchView(TemplateView):
             log_lines.append(log_line)
 
         def page_url(offset):
-            return reverse("search") + '?' + urllib.urlencode({
+            return reverse("search") + '?' + urllib.parse.urlencode({
                 'q': q,
                 'offset': offset,
             })

--- a/global/manage.py
+++ b/global/manage.py
@@ -35,7 +35,7 @@ except ImportError:
 # We haven't found anything helpful yet, so use development.
 if environment is None:
     try:
-        import configs.development.settings
+        from . import configs.development.settings
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))

--- a/global/manage.py
+++ b/global/manage.py
@@ -35,7 +35,7 @@ except ImportError:
 # We haven't found anything helpful yet, so use development.
 if environment is None:
     try:
-        from . import configs.development.settings
+        import configs.development.settings
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))

--- a/mcshred/src/MCShred.py
+++ b/mcshred/src/MCShred.py
@@ -20,7 +20,7 @@ def shred_to_lines(lines):
     tapeNumber = None
         
     for number, line in enumerate(lines):
-        line = line.decode('utf-8')
+        line = line
         try:
             if line.strip().startswith("Page"):
                 pageNumber = int(line.strip().lstrip("Page ").strip())
@@ -218,7 +218,7 @@ def output_lines_to_file(lines, output_file_name_and_path):
         try:
             outputFile.writelines(
                 list(map(
-                    lambda x: x.encode('utf8'),
+                    lambda x: x,
                     get_formatted_record_for(line),
                 ))
             )

--- a/mcshred/src/MCShred.py
+++ b/mcshred/src/MCShred.py
@@ -22,14 +22,14 @@ def shred_to_lines(lines):
     for number, line in enumerate(lines):
         line = line.decode('utf-8')
         try:
-            if line.strip().startswith(u"Page"):
-                pageNumber = int(line.strip().lstrip(u"Page ").strip())
-            elif line.strip().startswith(u"Tape "):
-                tapeNumber = line.lstrip(u"Tape ").strip()
+            if line.strip().startswith("Page"):
+                pageNumber = int(line.strip().lstrip("Page ").strip())
+            elif line.strip().startswith("Tape "):
+                tapeNumber = line.lstrip("Tape ").strip()
             else:
                 logLines.append(LogLine(pageNumber, tapeNumber, number, line))
         except:
-            print "Failed on line %i: %s" % (number+1, line)
+            print("Failed on line %i: %s" % (number+1, line))
             raise
 
     return logLines
@@ -87,12 +87,12 @@ def set_timestamp_speaker_and_text(line, timestamp_parts):
     if len(values) > timestamp_parts:
         line.set_speaker(values[timestamp_parts])
     else:
-        line.set_speaker(u"_note")
+        line.set_speaker("_note")
         
     if len(values) > (timestamp_parts + 1):
         line.set_text(" ".join(values[timestamp_parts + 1:]))
     else:
-        line.set_text(u"")
+        line.set_text("")
 
 def line_is_a_new_entry(line, timestamp_parts):
     
@@ -138,7 +138,7 @@ def translate_lines(translated_lines, verbose=False, timestamp_parts=DEFAULT_TIM
             if currentLine != None:
                 translatedLines.append(currentLine)
             if verbose:
-                print line.raw
+                print(line.raw)
             set_timestamp_speaker_and_text(line, timestamp_parts)
             currentLine = line
         elif currentLine != None:
@@ -178,17 +178,17 @@ def get_formatted_record_for(line):
     global last_page, last_tape
     if validate_line(line):
         lines = []
-        lines.append(u"\n[%s]\n" % get_timestamp_as_mission_time(line))
+        lines.append("\n[%s]\n" % get_timestamp_as_mission_time(line))
 #        lines.append(u"\n[%d]\n" % line.seconds_from_mission_start)
         if line.page != last_page:
-            lines.append(u"_page : %d\n" % line.page)
+            lines.append("_page : %d\n" % line.page)
             last_page = line.page
         if line.tape != last_tape:
-            lines.append(u"_tape : %s\n" % line.tape)
+            lines.append("_tape : %s\n" % line.tape)
             last_tape = line.tape
         if len(line.non_log_lines) > 0:
-            lines.append(u"_extra : %s\n" % "/n".join(line.non_log_lines))
-        lines.append(u"%s: %s" % (line.speaker, line.text,))
+            lines.append("_extra : %s\n" % "/n".join(line.non_log_lines))
+        lines.append("%s: %s" % (line.speaker, line.text,))
         return lines
     else:
         return []
@@ -204,12 +204,12 @@ def check_lines_are_in_sequence(lines):
 
 def report_errors_and_exit():
     if len(errors) > 0:
-        print "Shred returned errors, please check the following:"
+        print("Shred returned errors, please check the following:")
         for error in errors:
-            print error
+            print(error)
         sys.exit(1)
     
-    print "No errors found"    
+    print("No errors found")    
     sys.exit(0)
 
 def output_lines_to_file(lines, output_file_name_and_path):
@@ -217,13 +217,13 @@ def output_lines_to_file(lines, output_file_name_and_path):
     for i, line in enumerate(lines):
         try:
             outputFile.writelines(
-                map(
+                list(map(
                     lambda x: x.encode('utf8'),
                     get_formatted_record_for(line),
-                )
+                ))
             )
         except:
-            print >>sys.stderr, "Failure in line %i (raw line %i)" % (i, line.line)
+            print("Failure in line %i (raw line %i)" % (i, line.line), file=sys.stderr)
             raise
     outputFile.close()
 
@@ -299,9 +299,9 @@ if __name__ == "__main__":
     file_path = args[0]
     output_file = args[1]
     allRawLines = get_all_raw_lines(file_path)
-    print "Read in %d raw lines (%d non-blank)." % (len(allRawLines), len(filter(lambda x: x.raw.strip(), allRawLines)))
+    print("Read in %d raw lines (%d non-blank)." % (len(allRawLines), len([x for x in allRawLines if x.raw.strip()])))
     translated_lines = translate_lines(allRawLines, options.verbose, options.timestamp_parts)
-    print "Translated to %d lines." % len(translated_lines)
+    print("Translated to %d lines." % len(translated_lines))
     check_lines_are_in_sequence(translated_lines)
     
     amalgamated_lines = amalgamate_lines_by_timestamp(translated_lines)

--- a/mcshred/src/MCShred.py
+++ b/mcshred/src/MCShred.py
@@ -37,7 +37,7 @@ def shred_to_lines(lines):
 def get_all_raw_lines(path):
     translated_lines = []
     try:
-        file = open(path, "r")
+        file = open(path, encoding="utf-8")
         file_lines = file.readlines()
         shredded_lines = shred_to_lines(file_lines)
         translated_lines.extend(shredded_lines)
@@ -213,7 +213,7 @@ def report_errors_and_exit():
     sys.exit(0)
 
 def output_lines_to_file(lines, output_file_name_and_path):
-    outputFile = open(output_file_name_and_path, "w")
+    outputFile = open(output_file_name_and_path, "w", encoding="utf-8")
     for i, line in enumerate(lines):
         try:
             outputFile.writelines(

--- a/mcshred/src/MCShredTest.py
+++ b/mcshred/src/MCShredTest.py
@@ -24,45 +24,45 @@ class Test(unittest.TestCase):
         assert int(MCShred.sterilize_token("B")) == 8
         assert int(MCShred.sterilize_token("h")) == 4
         
-        assert int(MCShred.sterilize_token(u"00")) == 0
-        assert int(MCShred.sterilize_token(u"01")) == 1
-        assert int(MCShred.sterilize_token(u"l0")) == 10
-        assert int(MCShred.sterilize_token(u"BB")) == 88
-        assert int(MCShred.sterilize_token(u"Bh")) == 84
-        assert int(MCShred.sterilize_token(u"lo")) == 10
-        assert int(MCShred.sterilize_token(u"OQo")) == 0
-        assert int(MCShred.sterilize_token(u"iJI!Ll")) == 111111
-        assert int(MCShred.sterilize_token(u"B")) == 8
-        assert int(MCShred.sterilize_token(u"h")) == 4
+        assert int(MCShred.sterilize_token("00")) == 0
+        assert int(MCShred.sterilize_token("01")) == 1
+        assert int(MCShred.sterilize_token("l0")) == 10
+        assert int(MCShred.sterilize_token("BB")) == 88
+        assert int(MCShred.sterilize_token("Bh")) == 84
+        assert int(MCShred.sterilize_token("lo")) == 10
+        assert int(MCShred.sterilize_token("OQo")) == 0
+        assert int(MCShred.sterilize_token("iJI!Ll")) == 111111
+        assert int(MCShred.sterilize_token("B")) == 8
+        assert int(MCShred.sterilize_token("h")) == 4
     
     def test_log_line(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"00 01 03 59 CC This is the rest of the line")
+        logLine = MCShred.LogLine(5, "5/1", 1, "00 01 03 59 CC This is the rest of the line")
         
         assert logLine.page == 5
-        assert logLine.tape == u"5/1"
+        assert logLine.tape == "5/1"
         assert logLine.line == 1
-        assert logLine.raw == u"00 01 03 59 CC This is the rest of the line"
+        assert logLine.raw == "00 01 03 59 CC This is the rest of the line"
         
     def test_get_seconds_from_mission_start(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"01 02 03 59 CC This is the rest of the line")
+        logLine = MCShred.LogLine(5, "5/1", 1, "01 02 03 59 CC This is the rest of the line")
         expectedTime = (59 + (3 * 60) + (2 * 60 * 60) + (1 * 24 * 60 * 60))
 
         assert MCShred.get_seconds_from_mission_start(logLine, timestamp_parts=4) == expectedTime
 
     def test_get_seconds_from_mission_start_will_work_with_full_colon_seperated_timestamps(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"01:02:03:59 CC This is the rest of the line")
+        logLine = MCShred.LogLine(5, "5/1", 1, "01:02:03:59 CC This is the rest of the line")
         expectedTime = (59 + (3 * 60) + (2 * 60 * 60) + (1 * 24 * 60 * 60))
 
         assert MCShred.get_seconds_from_mission_start(logLine, timestamp_parts=4) == expectedTime
 
     def test_get_seconds_from_mission_start_will_work_with_abbreviated_timestamps(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"25:03:59 CC This is the rest of the line")
+        logLine = MCShred.LogLine(5, "5/1", 1, "25:03:59 CC This is the rest of the line")
         expectedTime = (59 + (3 * 60) + (25 * 60 * 60))
 
         assert MCShred.get_seconds_from_mission_start(logLine, timestamp_parts=3) == expectedTime
 
     def test_set_timestamp_speaker_and_text(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"01 02 03 59 CC This is the rest of the line")
+        logLine = MCShred.LogLine(5, "5/1", 1, "01 02 03 59 CC This is the rest of the line")
         
         MCShred.set_timestamp_speaker_and_text(logLine, timestamp_parts=4)
         
@@ -72,14 +72,14 @@ class Test(unittest.TestCase):
 #        print(logLine.seconds_from_mission_start)
         
         assert logLine.seconds_from_mission_start == expectedTime
-        assert logLine.speaker == u"CC"
+        assert logLine.speaker == "CC"
         assert logLine.text == "This is the rest of the line"
         
     def test_line_is_a_new_entry(self):
         timestamp_parts = 4
-        logLine1 = MCShred.LogLine(5, u"5/1", 1, u"01 02 03 59 CC This is the rest of the line")
-        logLine2 = MCShred.LogLine(5, u"5/1", 2, u"except for this thing because it's actually")
-        logLine3 = MCShred.LogLine(5, u"5/1", 3, u"a three line comment")
+        logLine1 = MCShred.LogLine(5, "5/1", 1, "01 02 03 59 CC This is the rest of the line")
+        logLine2 = MCShred.LogLine(5, "5/1", 2, "except for this thing because it's actually")
+        logLine3 = MCShred.LogLine(5, "5/1", 3, "a three line comment")
         
         assert MCShred.line_is_a_new_entry(logLine1, timestamp_parts) == True
         assert MCShred.line_is_a_new_entry(logLine2, timestamp_parts) == False
@@ -87,19 +87,19 @@ class Test(unittest.TestCase):
 
     def test_line_is_a_new_entry_will_work_with_three_timestamp_parts(self):
         timestamp_parts = 3
-        logLine1 = MCShred.LogLine(5, u"5/1", 1, u"26 03 59 CC This is the rest of the line")
-        logLine2 = MCShred.LogLine(5, u"5/1", 2, u"except for this thing because it's actually")
-        logLine3 = MCShred.LogLine(5, u"5/1", 3, u"a three line comment")
+        logLine1 = MCShred.LogLine(5, "5/1", 1, "26 03 59 CC This is the rest of the line")
+        logLine2 = MCShred.LogLine(5, "5/1", 2, "except for this thing because it's actually")
+        logLine3 = MCShred.LogLine(5, "5/1", 3, "a three line comment")
 
         assert MCShred.line_is_a_new_entry(logLine1, timestamp_parts) == True
         assert MCShred.line_is_a_new_entry(logLine2, timestamp_parts) == False
         assert MCShred.line_is_a_new_entry(logLine3, timestamp_parts) == False
 
     def test_shred_to_lines(self):
-        logLine0 = u"Tape 3/2"
-        logLine1 = u"01 02 03 59 CC This is the rest of the line"
-        logLine2 = u"except for this thing because it's actually"
-        logLine3 = u"a three line comment"
+        logLine0 = "Tape 3/2"
+        logLine1 = "01 02 03 59 CC This is the rest of the line"
+        logLine2 = "except for this thing because it's actually"
+        logLine3 = "a three line comment"
         
         logLines = (logLine0, logLine1, logLine2, logLine3,)
         
@@ -109,18 +109,18 @@ class Test(unittest.TestCase):
         assert shreddedLines[0].page == 1
         assert shreddedLines[1].page == 1
         assert shreddedLines[2].page == 1
-        assert shreddedLines[0].tape == u"3/2"
-        assert shreddedLines[1].tape == u"3/2"
-        assert shreddedLines[2].tape == u"3/2"
+        assert shreddedLines[0].tape == "3/2"
+        assert shreddedLines[1].tape == "3/2"
+        assert shreddedLines[2].tape == "3/2"
         assert shreddedLines[0].raw == logLine1
         assert shreddedLines[1].raw == logLine2
         assert shreddedLines[2].raw == logLine3
         
     def test_translate_lines(self):
-        logLine0 = u"Tape 3/2"
-        logLine1 = u"01 02 03 59 CC This is the rest of the line"
-        logLine2 = u"except for this thing because it's actually"
-        logLine3 = u"a three line comment"
+        logLine0 = "Tape 3/2"
+        logLine1 = "01 02 03 59 CC This is the rest of the line"
+        logLine2 = "except for this thing because it's actually"
+        logLine3 = "a three line comment"
         
         logLines = (logLine0, logLine1, logLine2, logLine3,)
         
@@ -130,24 +130,24 @@ class Test(unittest.TestCase):
         
         assert len(translatedLines) == 1
         assert translatedLines[0].page == 1
-        assert translatedLines[0].tape == u"3/2"
-        assert translatedLines[0].speaker == u"CC"
-        assert translatedLines[0].text == u"This is the rest of the line" + "     " + logLine2 + "     " + logLine3
+        assert translatedLines[0].tape == "3/2"
+        assert translatedLines[0].speaker == "CC"
+        assert translatedLines[0].text == "This is the rest of the line" + "     " + logLine2 + "     " + logLine3
 
     def test_get_filename_for(self):
-        assert MCShred.get_file_name_for(0) == u"000.txt"
-        assert MCShred.get_file_name_for(1) == u"001.txt"
-        assert MCShred.get_file_name_for(12) == u"012.txt"
-        assert MCShred.get_file_name_for(304) == u"304.txt"
-        assert MCShred.get_file_name_for(200) == u"200.txt"
-        assert MCShred.get_file_name_for(003) == u"003.txt"
+        assert MCShred.get_file_name_for(0) == "000.txt"
+        assert MCShred.get_file_name_for(1) == "001.txt"
+        assert MCShred.get_file_name_for(12) == "012.txt"
+        assert MCShred.get_file_name_for(304) == "304.txt"
+        assert MCShred.get_file_name_for(200) == "200.txt"
+        assert MCShred.get_file_name_for(0o03) == "003.txt"
         
     def test_is_a_non_log_line(self):
-        logLine0 = make_log_line(u"Tape 3/2")
-        logLine1 = make_log_line(u"01 02 03 59 CC This is the rest of the line")
-        logLine2 = make_log_line(u"  except for this thing because it's actually")
-        logLine3 = make_log_line(u"    ( other weird text Thing )")
-        logLine4 = make_log_line(u"")
+        logLine0 = make_log_line("Tape 3/2")
+        logLine1 = make_log_line("01 02 03 59 CC This is the rest of the line")
+        logLine2 = make_log_line("  except for this thing because it's actually")
+        logLine3 = make_log_line("    ( other weird text Thing )")
+        logLine4 = make_log_line("")
         assert MCShred.is_a_non_log_line(logLine0) == False
         assert MCShred.is_a_non_log_line(logLine1) == False
         assert MCShred.is_a_non_log_line(logLine2) == True
@@ -155,14 +155,14 @@ class Test(unittest.TestCase):
         assert MCShred.is_a_non_log_line(logLine4) == True
 
     def test_if_no_speaker_indicated_it_is_considered_a_note(self):
-        logLine = MCShred.LogLine(5, u"5/1", 1, u"01 02 03 59")
+        logLine = MCShred.LogLine(5, "5/1", 1, "01 02 03 59")
 
         MCShred.set_timestamp_speaker_and_text(logLine, timestamp_parts=4)
 
         expectedTime = (59 + (3 * 60) + (2 * 60 * 60) + (1 * 24 * 60 * 60))
 
         assert logLine.seconds_from_mission_start == expectedTime
-        assert logLine.speaker == u"_note"
+        assert logLine.speaker == "_note"
         assert logLine.text == ""
 
 

--- a/tools/offset_trancript_pages.py
+++ b/tools/offset_trancript_pages.py
@@ -12,8 +12,8 @@ transcript_file = sys.argv[1]
 offset          = int( sys.argv[2] )
 
 os.rename( transcript_file, transcript_file+"~" )
-source      = open( transcript_file+"~", "r" )
-destination = open( transcript_file, "w" )
+source      = open( transcript_file+"~", encoding="utf-8" )
+destination = open( transcript_file, "w", encoding="utf-8" )
 
 for line in source:
     fixed_line = line

--- a/tools/offset_trancript_pages.py
+++ b/tools/offset_trancript_pages.py
@@ -3,9 +3,9 @@
 import os, sys
 
 if len(sys.argv) < 3:
-    print >>sys.stderr, "Usage: python offset_transcript_pages.py [transcript file] [offset]"
-    print >>sys.stderr
-    print >>sys.stderr, "Mass-modifies transcript page numbers by a specified offset."
+    print("Usage: python offset_transcript_pages.py [transcript file] [offset]", file=sys.stderr)
+    print(file=sys.stderr)
+    print("Mass-modifies transcript page numbers by a specified offset.", file=sys.stderr)
     sys.exit(1)
 
 transcript_file = sys.argv[1]

--- a/tools/pdf_to_images.py
+++ b/tools/pdf_to_images.py
@@ -14,7 +14,7 @@ requires = {
 }
 
 unmet_requirements = []
-for name, command in requires.iteritems():
+for name, command in requires.items():
     tf = tempfile.TemporaryFile()
     try:
         subprocess.call( command, stdin=None, stdout=tf, stderr=tf )
@@ -22,13 +22,13 @@ for name, command in requires.iteritems():
         unmet_requirements += [ '%s (%s)' % ( name, command ) ]
 
 if unmet_requirements:
-    print >>sys.stderr, 'Unmet requirements: %s' % ', '.join( unmet_requirements )
+    print('Unmet requirements: %s' % ', '.join( unmet_requirements ), file=sys.stderr)
     sys.exit(1)
 
 if len(sys.argv) < 2:
-    print >>sys.stderr, "Usage: python pdf_to_images.py [pdf file]"
-    print >>sys.stderr
-    print >>sys.stderr, "Converts a PDF into a directory full of PNGs. Requires ImageMagick and optipng."
+    print("Usage: python pdf_to_images.py [pdf file]", file=sys.stderr)
+    print(file=sys.stderr)
+    print("Converts a PDF into a directory full of PNGs. Requires ImageMagick and optipng.", file=sys.stderr)
     sys.exit(1)
 
 pdf_file = sys.argv[1]
@@ -41,16 +41,16 @@ def generate_image( image_name, page, resize_dimensions=None ):
     png_file = os.path.join(output_dir, '%s.png' % image_name)
     
     # Convert and resize in two passes to get the smallest filesize
-    print "Converting page %s to %s..." % ( page, png_file )
+    print("Converting page %s to %s..." % ( page, png_file ))
     exit_code = subprocess.call([
         'convert', 
         '-density', '300', 
-        u'%s[%s]' % (pdf_file, page-1), # zero indexed pages
+        '%s[%s]' % (pdf_file, page-1), # zero indexed pages
         png_file,
     ])
     
     if not exit_code:
-        print "Resizing %s..." % png_file
+        print("Resizing %s..." % png_file)
         # HACK: Assumes that the input image is black and white,
         #       and 16 colors will suffice for antialiasing
         exit_code = subprocess.call([
@@ -64,7 +64,7 @@ def generate_image( image_name, page, resize_dimensions=None ):
         
     if not exit_code:
         # This usually takes many times longer than the extract
-        print "Optimising %s..." % png_file
+        print("Optimising %s..." % png_file)
         optimise_exit_code = subprocess.call([
             'optipng',
             '-q',
@@ -72,7 +72,7 @@ def generate_image( image_name, page, resize_dimensions=None ):
             png_file,
         ])
         if optimise_exit_code != 0:
-            print >>sys.stderr, "optipng failed"
+            print("optipng failed", file=sys.stderr)
             sys.exit(1)
     
     return exit_code

--- a/tools/resize.py
+++ b/tools/resize.py
@@ -17,7 +17,7 @@ for filename in os.listdir("."):
         if os.path.exists(thumbname):
             pass
             #continue
-        print "Converting %s" % filename
+        print("Converting %s" % filename)
         # Step one: big version
         source = Image.open(filename)
         thumbnail = source.copy()

--- a/tools/s3-upload.py
+++ b/tools/s3-upload.py
@@ -25,7 +25,7 @@ for root, _, filenames in os.walk(sys.argv[1]):
         remote_path = path.abspath(path.join(sys.argv[2], root, filename))
         k = Key(bucket, remote_path)
         if not k.exists():
-            print("Uploading %s" % remote_path)
+            print(("Uploading %s" % remote_path))
             k.set_contents_from_filename(local_path,
                                          headers={'Cache-Control': 'max-age=%s' % TTL})
             k.set_acl('public-read')

--- a/website/apps/common/tests/__init__.py
+++ b/website/apps/common/tests/__init__.py
@@ -1,2 +1,2 @@
-from test_response import *
+from .test_response import *
 

--- a/website/apps/people/views.py
+++ b/website/apps/people/views.py
@@ -6,7 +6,7 @@ from backend.api import Character
 def mission_people(request, role=None):
     character_query = Character.Query(request.redis_conn, request.mission.name)
     character_ordering = [
-        identifier.decode('utf-8')
+        identifier
         for identifier in
         list(request.redis_conn.lrange("character-ordering:%s" % request.mission.name, 0, -1))
     ]

--- a/website/apps/search/views.py
+++ b/website/apps/search/views.py
@@ -1,5 +1,5 @@
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from django.views.generic import TemplateView
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -90,7 +90,7 @@ class SearchView(MemorialMixin, TemplateView):
             log_lines.append(log_line)
 
         def page_url(offset):
-            return reverse("search") + '?' + urllib.urlencode({
+            return reverse("search") + '?' + urllib.parse.urlencode({
                 'q': q.encode('utf-8'),
                 'offset': offset,
             })
@@ -136,7 +136,7 @@ class SearchView(MemorialMixin, TemplateView):
         )
         if not error_info:
             error_info = {}
-        if error_info.has_key('classic_moment_quote'):
+        if 'classic_moment_quote' in error_info:
             error_quote = LogLine(
                 self.request.redis_conn,
                 self.request.mission.main_transcript,

--- a/website/apps/search/views.py
+++ b/website/apps/search/views.py
@@ -91,7 +91,7 @@ class SearchView(MemorialMixin, TemplateView):
 
         def page_url(offset):
             return reverse("search") + '?' + urllib.parse.urlencode({
-                'q': q.encode('utf-8'),
+                'q': q,
                 'offset': offset,
             })
 

--- a/website/apps/transcripts/middleware.py
+++ b/website/apps/transcripts/middleware.py
@@ -1,8 +1,8 @@
 import os
-import redis
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from backend.api import Mission
+from backend.util import redis_connection
 from transcripts.templatetags.missiontime import component_suppression
 
 class RedisMiddleware(object):
@@ -10,10 +10,7 @@ class RedisMiddleware(object):
     Add a redis object to every request
     """
     def process_request(self, request):
-        request.redis_conn = redis.from_url(
-            os.environ.get("REDIS_URL", "redis://localhost:6379"),
-            decode_responses=True
-        )
+        request.redis_conn = redis_connection
 
 class MissionMiddleware(object):
     """

--- a/website/apps/transcripts/middleware.py
+++ b/website/apps/transcripts/middleware.py
@@ -10,7 +10,10 @@ class RedisMiddleware(object):
     Add a redis object to every request
     """
     def process_request(self, request):
-        request.redis_conn = redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379"))
+        request.redis_conn = redis.from_url(
+            os.environ.get("REDIS_URL", "redis://localhost:6379"),
+            decode_responses=True
+        )
 
 class MissionMiddleware(object):
     """

--- a/website/apps/transcripts/templatetags/characters.py
+++ b/website/apps/transcripts/templatetags/characters.py
@@ -23,7 +23,7 @@ def avatar_and_name(speaker, mission_name, timestamp=None):
     if current_speaker.short_name_lang:
         short_name_lang = format_html(" lang='{}'", current_speaker.short_name_lang)
 
-    detail = format_html(u"""
+    detail = format_html("""
           <img src='{avatar}' alt='' width='48' height='48'>
           <span{short_name_lang}>{short_name}</span>
         """,
@@ -42,7 +42,7 @@ def avatar_and_name(speaker, mission_name, timestamp=None):
         url = '%s#%s' % (reverse("people"), current_speaker.slug)
 
     if url:
-        return format_html(u"<a href='{}'>{}</a>", url, detail)
+        return format_html("<a href='{}'>{}</a>", url, detail)
     else:
         return detail
 
@@ -74,6 +74,6 @@ def avatar(speaker, mission_name, timestamp=None):
         url = '%s#%s' % (reverse("people"), current_speaker.slug)
 
     if url:
-        return format_html(u"<a href='{}'>{}</a>", url, detail)
+        return format_html("<a href='{}'>{}</a>", url, detail)
     else:
         return detail

--- a/website/apps/transcripts/templatetags/linkify.py
+++ b/website/apps/transcripts/templatetags/linkify.py
@@ -46,7 +46,7 @@ def glossary_link(match, request):
         display = match.group(1)
 
     if title:
-        display = u"<%(tag)s class='jargon' title='%(title)s'>%(text)s</%(tag)s>" % {
+        display = "<%(tag)s class='jargon' title='%(title)s'>%(text)s</%(tag)s>" % {
             "tag":   tag,
             "title": title,
             "text":  display,
@@ -54,13 +54,13 @@ def glossary_link(match, request):
 
     if more_information:
         if gitem is not None:
-            return u"<a href='%s#%s'>%s</a>" % (
+            return "<a href='%s#%s'>%s</a>" % (
                 reverse("glossary"),
                 gitem.slug,
                 display,
             )
         else:
-            return u"<a href='%s#%s'>%s</a>" % (
+            return "<a href='%s#%s'>%s</a>" % (
                 reverse("glossary"),
                 slugify(match.group(1)),
                 display,
@@ -93,7 +93,7 @@ def linkify(text, request=None):
         'glossary': lambda m: glossary_link(m, request),
     }
     
-    for link_type, link_maker in link_types.items():
+    for link_type, link_maker in list(link_types.items()):
         # first, the "full" version
         text = re.sub(
             r"\[%s:([^]]+)\|([^]]+)\]" % link_type,

--- a/website/apps/transcripts/templatetags/missiontime.py
+++ b/website/apps/transcripts/templatetags/missiontime.py
@@ -29,7 +29,7 @@ def mission_time(seconds, separator=':', enable_suppression=False):
     Takes a timestamp and a separator and returns a mission time string
     e.g. Passing in 63 seconds and ':' would return '00:00:01:03'.
     """
-    if isinstance(seconds, basestring) and separator in seconds:
+    if isinstance(seconds, str) and separator in seconds:
         components = seconds.split(':', 4)
         if len(components) < 4:
             components = ['00' for x in range(4-len(components))] + components
@@ -93,6 +93,6 @@ def selection_url_in_transcript(context, start_seconds, transcript, end_seconds=
     
     # Render the URL
     url = reverse("view_range", kwargs=url_args)
-    if isinstance(start_seconds, basestring):
+    if isinstance(start_seconds, str):
         start_seconds = timestamp_to_seconds(start_seconds)
     return '%s#log-line-%i' % ( url, start_seconds )

--- a/website/apps/transcripts/views.py
+++ b/website/apps/transcripts/views.py
@@ -395,12 +395,9 @@ class OriginalView(MemorialMixin, TemplateView):
 
     def first_log_line(self):
         try:
-            return next(iter(self.log_lines()))
+            return next(self.transcript_query().transcript_page(self.page).items())
         except StopIteration:
             return None
-
-    def log_lines(self):
-        return list(self.transcript_query().transcript_page(self.page).items())
 
     def transcript_query(self):
         return self.log_line_query().transcript(self.get_transcript_name())

--- a/website/apps/transcripts/views.py
+++ b/website/apps/transcripts/views.py
@@ -395,7 +395,7 @@ class OriginalView(MemorialMixin, TemplateView):
 
     def first_log_line(self):
         try:
-            return next(self.log_lines())
+            return next(iter(self.log_lines()))
         except StopIteration:
             return None
 

--- a/website/apps/transcripts/views.py
+++ b/website/apps/transcripts/views.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 import os.path
 from django.conf import settings
 from django.http import Http404, HttpResponseRedirect, HttpResponse
@@ -400,7 +400,7 @@ class OriginalView(MemorialMixin, TemplateView):
             return None
 
     def log_lines(self):
-        return self.transcript_query().transcript_page(self.page).items()
+        return list(self.transcript_query().transcript_page(self.page).items())
 
     def transcript_query(self):
         return self.log_line_query().transcript(self.get_transcript_name())
@@ -439,7 +439,7 @@ class ProgressiveFileWrapper(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         self._wait()
         data = self.filelike.read(self.blksize)
         if data:

--- a/website/manage.py
+++ b/website/manage.py
@@ -35,7 +35,7 @@ except ImportError:
 # We haven't found anything helpful yet, so use development.
 if environment is None:
     try:
-        import configs.development.settings
+        from . import configs.development.settings
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))

--- a/website/manage.py
+++ b/website/manage.py
@@ -35,7 +35,7 @@ except ImportError:
 # We haven't found anything helpful yet, so use development.
 if environment is None:
     try:
-        from . import configs.development.settings
+        import configs.development.settings
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "configs.development.settings")
         environment = 'development'
         sys.path.insert(0, os.path.join(project_path, 'configs', environment))


### PR DESCRIPTION
As a precursor to upgrading the OS and our various dependencies to more current versions, this upgrades us first to Python 3.

I'd recommend reviewing this PR commit-by-commit as d312691 is the result of running `2to3 -wn .` to automatically translate our code to Python 3 compatible. And it mostly worked! The remainder of the issues were:

- A few Python3-incompatible syntax things (`from . import blah.blah`, implicit comparison of `None` and `int`, `next()` not working directly on lists anymore)
- Handling UTF-8 and b-string things wherever necessary (in and out of Redis, in stdout, and in and out of Xapier, off the file-system)