### PR TITLE
Ensure we only rebuild indexes when necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,20 @@ RUN mkdir -p /src
 WORKDIR /src
 COPY requirements.txt /src/
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install -r requirements.txt
-COPY . /src/
+
+# Only copy what we need for indexing and stats generation at this stage
+COPY missions /src/missions/
+COPY backend /src/backend/
+COPY ext /src/ext/
+COPY Makefile /src/
+
 ENV PYTHONIOENCODING utf-8:ignore
 RUN /etc/init.d/redis-server start && \
-  make all && \
+  make reindex statsporn && \
   redis-cli shutdown save
+
+COPY . /src/
+RUN make collectstatic
 
 EXPOSE 8000
 EXPOSE 8001

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PROJECT_DOMAIN           ?= dev.spacelog.org
 
 all: reindex collectstatic
 
-collectstatic: productioncss statsporn
+collectstatic: productioncss
 	DJANGOENV=live $(PYTHON) -m website.manage collectstatic --noinput --ignore=*.scss
 	DJANGOENV=live $(PYTHON) -m global.manage collectstatic --noinput --ignore=*.scss
 


### PR DESCRIPTION
Previously, we were reindexing on every container rebuild, regardless of whether the mission data or backend code had changed.

Given these are the only things that actually impact indexing, though, we can simply copy those to the container, reindex, then copy everything else, meaning that in the majority of cases, container builds are much faster because they're not spending 3-4 minutes reindexing.

To make this work, because our Makefile doesn't properly describe the dependency graph, we had to break the link between stats and collectstatic. But that's OK, probably.