### PR TITLE
Upgrade to Django 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.20.4 AS overmind-builder
 
 RUN go install github.com/DarthSim/overmind/v2@latest
 
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -yq \

--- a/global/apps/homepage/middleware.py
+++ b/global/apps/homepage/middleware.py
@@ -1,6 +1,7 @@
+from django.utils.deprecation import MiddlewareMixin
 from backend.util import redis_connection
 
-class RedisMiddleware(object):
+class RedisMiddleware(MiddlewareMixin):
     """
     Add a redis object to every request
     """

--- a/global/apps/homepage/views.py
+++ b/global/apps/homepage/views.py
@@ -140,7 +140,7 @@ def _get_reading_list(country_code):
 
 @cache_control(no_cache=True)
 def about(request):
-    country_code = request.META.get('HTTP_CF_IPCOUNTRY')
+    country_code = request.headers.get('cf-ipcountry')
     if country_code is None:
         country_code = request.META.get(
             'GEOIP_COUNTRY_CODE',

--- a/global/apps/homepage/views.py
+++ b/global/apps/homepage/views.py
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.views.decorators.cache import cache_control
 from urllib.parse import quote
@@ -103,7 +103,8 @@ def homepage(request):
         mission for mission in list(Mission.Query(request.redis_conn))
         if mission.incomplete and mission.featured
     ]
-    return render_to_response(
+    return render(
+        request,
         'homepage/homepage.html',
         {
             'missions': missions,
@@ -202,7 +203,8 @@ def about(request):
 
     contributors = [ _as_dict(contributor) for contributor in contributors ]
 
-    return render_to_response(
+    return render(
+        request,
         'pages/about.html',
         {
             'READING_LISTS': _get_reading_list(country_code),
@@ -213,7 +215,8 @@ def about(request):
 
 @cache_control(no_cache=True)
 def press(request):
-    return render_to_response(
+    return render(
+            request,
             'pages/press.html',
             {
                 'page': 'press',
@@ -223,7 +226,8 @@ def press(request):
 
 @cache_control(no_cache=True)
 def get_involved(request):
-    return render_to_response(
+    return render(
+            request,
             'pages/get-involved.html',
             {'page': 'get-involved'},
             )

--- a/global/apps/search/views.py
+++ b/global/apps/search/views.py
@@ -1,7 +1,7 @@
 import os
 import urllib.request, urllib.parse, urllib.error
 from django.views.generic import TemplateView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.utils.safestring import mark_safe
 import xappy

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -124,7 +124,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'homepage.middleware.RedisMiddleware',

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -82,8 +82,10 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
     },
+    "digest_free_staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedStaticFilesStorage',
+    },
 }
-STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/global/configs/settings.py
+++ b/global/configs/settings.py
@@ -65,7 +65,6 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale
-USE_L10N = True
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
@@ -76,7 +75,14 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
 STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),

--- a/global/templates/_base/masthead.html
+++ b/global/templates/_base/masthead.html
@@ -9,21 +9,21 @@
     
     <nav>
       <ul>
-        {% ifequal page "about" %}
+        {% if page == "about" %}
         <li><span class="current">About</span></li>
         {% else %}
         <li><a href="/about/">About</a></li>
-        {% endifequal %}
-        {% ifequal page "press" %}
+        {% endif %}
+        {% if page == "press" %}
         <li><span class="current">Press</span></li>
         {% else %}
         <li><a href="/press/">Press</a></li>
-        {% endifequal %}
-        {% ifequal page "get-involved" %}
+        {% endif %}
+        {% if page == "get-involved" %}
         <li><span class="current">Get Involved</span></li>
         {% else %}
         <li><a href="/get-involved/">Get Involved</a></li>
-        {% endifequal %}
+        {% endif %}
       </ul>
     </nav>
     

--- a/global/templates/base.html
+++ b/global/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}{% load missionstatic %}<!DOCTYPE html>
+{% load static %}{% load missionstatic %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"

--- a/global/templates/holding.html
+++ b/global/templates/holding.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html>
 <head>
   <title>We'll be back soon.</title>

--- a/global/templates/pages/get-involved.html
+++ b/global/templates/pages/get-involved.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}Getting Involved with Spacelog{% endblock %}
 

--- a/global/urls.py
+++ b/global/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import path
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 #from search.views import SearchView
 from homepage import views as homepage_views
 
 urlpatterns = [
-    url(r'^$', homepage_views.homepage, name="homepage"),
-    url(r'^about/$', homepage_views.about, name="about"),
-    url(r'^press/$', homepage_views.press, name="press"),
-    url(r'^get-involved/$', homepage_views.get_involved, name="get_involved"),
+    path('', homepage_views.homepage, name="homepage"),
+    path('about/', homepage_views.about, name="about"),
+    path('press/', homepage_views.press, name="press"),
+    path('get-involved/', homepage_views.get_involved, name="get_involved"),
     # url(r'^search/$', SearchView.as_view(), name="search"),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyScss~=1.4
 eventlet~=0.20.1
 whitenoise~=4.1.4
 greenlet~=1.1.3
+tzdata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-django~=1.11.0
+django~=5.0
 redis==2.10.6
 boto==2.49.0
 gunicorn==19.3.0
-pyScss==1.3.4
+pyScss~=1.4
 eventlet~=0.20.1
 whitenoise~=4.1.4
 greenlet~=1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ boto==2.49.0
 gunicorn~=21.2
 pyScss~=1.4
 eventlet~=0.36.1
-whitenoise~=4.1.4
+whitenoise~=6.0
 greenlet~=3.0
 tzdata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 django~=5.0
 redis==2.10.6
 boto==2.49.0
-gunicorn==19.3.0
+gunicorn~=21.2
 pyScss~=1.4
-eventlet~=0.20.1
+eventlet~=0.36.1
 whitenoise~=4.1.4
-greenlet~=1.1.3
+greenlet~=3.0
 tzdata

--- a/website/apps/search/views.py
+++ b/website/apps/search/views.py
@@ -1,7 +1,7 @@
 import os
 import urllib.request, urllib.parse, urllib.error
 from django.views.generic import TemplateView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.utils.safestring import mark_safe
 import xappy

--- a/website/apps/transcripts/middleware.py
+++ b/website/apps/transcripts/middleware.py
@@ -1,18 +1,17 @@
-import os
-from django.shortcuts import render_to_response
 from django.template import RequestContext
 from backend.api import Mission
 from backend.util import redis_connection
 from transcripts.templatetags.missiontime import component_suppression
+from django.utils.deprecation import MiddlewareMixin
 
-class RedisMiddleware(object):
+class RedisMiddleware(MiddlewareMixin):
     """
     Add a redis object to every request
     """
     def process_request(self, request):
         request.redis_conn = redis_connection
 
-class MissionMiddleware(object):
+class MissionMiddleware(MiddlewareMixin):
     """
     Adds a mission object into every request.
     """

--- a/website/apps/transcripts/templatetags/characters.py
+++ b/website/apps/transcripts/templatetags/characters.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.utils.html import format_html
 from .missionstatic import mission_static

--- a/website/apps/transcripts/templatetags/linkify.py
+++ b/website/apps/transcripts/templatetags/linkify.py
@@ -1,7 +1,7 @@
 import re
 from django.template import Library
 from django.template.defaultfilters import slugify
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from backend.api import Glossary
 from backend.util import timestamp_to_seconds

--- a/website/apps/transcripts/templatetags/missionstatic.py
+++ b/website/apps/transcripts/templatetags/missionstatic.py
@@ -2,14 +2,11 @@ import os
 from django import template
 from django.conf import settings
 from django.contrib.staticfiles.storage import (
-    get_storage_class, staticfiles_storage,
+    storages, staticfiles_storage,
 )
 
 
-staticfiles_digest_free_storage = get_storage_class(
-    settings.STATICFILES_DIGEST_FREE_STORAGE,
-)()
-
+staticfiles_digest_free_storage = storages["digest_free_staticfiles"]
 
 def full_path(mission, *path):
     """
@@ -22,7 +19,7 @@ def full_path(mission, *path):
 
 def digest_free_static(path):
     """
-    Uses STATICFILES_DIGEST_FREE_STORAGE instead of STATICFILES_STORAGE
+    Uses storages["digest_free_staticfiles"] instead of storages["staticfiles"]
     to produce a URL that doesn't include the digest of the file's current
     contents.
 

--- a/website/apps/transcripts/templatetags/missiontime.py
+++ b/website/apps/transcripts/templatetags/missiontime.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from backend.util import timestamp_to_seconds
 
 import threading

--- a/website/apps/transcripts/views.py
+++ b/website/apps/transcripts/views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.http import Http404, HttpResponseRedirect, HttpResponse
 from django.views.generic import TemplateView
 from django.views.decorators.http import condition
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from website.apps.common.views import JsonTemplateView
 from backend.api import LogLine, Act
 from backend.util import timestamp_to_seconds

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -132,7 +132,7 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'transcripts.middleware.RedisMiddleware',

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -82,8 +82,10 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
     },
+    "digest_free_staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedStaticFilesStorage',
+    },
 }
-STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),
 ]

--- a/website/configs/settings.py
+++ b/website/configs/settings.py
@@ -65,7 +65,6 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale
-USE_L10N = True
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
@@ -76,7 +75,14 @@ MEDIA_ROOT = ''
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = ''
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
 STATICFILES_DIGEST_FREE_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(SITE_ROOT, 'static'),

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}{% load missionstatic %}<!DOCTYPE html>
+{% load static %}{% load missionstatic %}<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:og="http://opengraphprotocol.org/schema/"
       xmlns:fb="http://www.facebook.com/2008/fbml"

--- a/website/templates/homepage/homepage.html
+++ b/website/templates/homepage/homepage.html
@@ -19,11 +19,11 @@
 <ol>
 {% for number, act in acts %}
   <li>
-    {% ifequal 1 number %}
+    {% if 1 == number %}
     <a href='{% url "view_page" %}'>
     {% else %}
     <a href='{% timestamp_to_url act.start %}'>
-    {% endifequal %}
+    {% endif %}
         {% if act.homepage %}
         <img src="{% mission_static mission.name "images/homepage" act.homepage %}"
            alt="" width="220" height="140"/>

--- a/website/templates/homepage/memorial.html
+++ b/website/templates/homepage/memorial.html
@@ -38,11 +38,11 @@
 {% for group in people %}
   {% for person in group.members %}
     {% cycle "<div class='group'>" "" ""  %}
-    {% ifequal group.view "full" %}
+    {% if group.view == "full" %}
       {% include "people/_person.html" %}
     {% else %}
       {% include "people/_simple_person.html" %}
-    {% endifequal %}
+    {% endif %}
     {% cycle "" "" "</div>"  %}
   {% endfor %}
 {% endfor %}

--- a/website/templates/homepage/memorial.html
+++ b/website/templates/homepage/memorial.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}

--- a/website/templates/people/people.html
+++ b/website/templates/people/people.html
@@ -12,11 +12,11 @@
   <h2>{{ group.name }}</h2>
   {% for person in group.members %}
     {% cycle "<div class='group'>" "" ""  %}
-    {% ifequal group.view "full" %}
+    {% if group.view == "full" %}
       {% include "people/_person.html" %}
     {% else %}
       {% include "people/_simple_person.html" %}
-    {% endifequal %}
+    {% endif %}
     {% cycle "" "" "</div>"  %}
   {% endfor %}
 {% endfor %}

--- a/website/templates/transcripts/page.html
+++ b/website/templates/transcripts/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load missionstatic %}
 {% load missiontime %}
 {% load linkify %}

--- a/website/templates/transcripts/phases.html
+++ b/website/templates/transcripts/phases.html
@@ -30,11 +30,11 @@
 
   <div class='details'>
     <h1>{{ act.title }}</h1>
-    {% ifequal act.number 0 %}
+    {% if act.number == 0 %}
     <a class='league-gothic read-button' href="{% url "view_page" %}">Start reading</a>
     {% else %}
     <a class='league-gothic read-button' href="{% timestamp_to_url act.start %}">Start reading</a>
-    {% endifequal %}
+    {% endif %}
 
     <p class='description'>{{ act.description|linkify }}</p>
 

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from glossary.views import GlossaryView
@@ -11,21 +11,21 @@ from transcripts.views import PageView, PhasesView, RangeView, ErrorView, Origin
 tspatt = r'-?\d+:\d+:\d+:\d+'
 
 urlpatterns = [
-    url(r'^$', HomepageView.as_view(), name="homepage"),
-    url(r'^homepage-quote/$', HomepageQuoteView.as_view()),
-    url(r'^about/$', AboutView.as_view(), name="about"),
-    url(r'^page/(?:(?P<transcript>[-_\w]+)/)?$', PageView.as_view(), name="view_page"),
-    url(r'^page/(?P<start>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', PageView.as_view(), name="view_page"),
-    url(r'^(?P<start>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', RangeView.as_view(), name="view_range"),
-    url(r'^stream/(?P<start>' + tspatt + ')/?$', transcripts_views.stream, name="stream"),
-    url(r'^(?P<start>' + tspatt + ')/(?P<end>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', RangeView.as_view(), name="view_range"),
-    url(r'^phases/$', PhasesView.as_view(), name="phases"),
-    url(r'^phases/(?P<phase_number>\d+)/$', PhasesView.as_view(), name="phases"),
-    url(r'^search/$', SearchView.as_view(), name="search"),
-    url(r'^people/$', PeopleView.as_view(), name="people"),
-    url(r'^people/(?P<role>[-_\w]+)/$', PeopleView.as_view(), name="people"),
-    url(r'^glossary/$', GlossaryView.as_view(), name="glossary"),
-    url(r'^original/(?:(?P<transcript>[-_\w]+)/)?(?P<page>-?\d+)/$', OriginalView.as_view(), name="original"),
+    path('', HomepageView.as_view(), name="homepage"),
+    path('homepage-quote/', HomepageQuoteView.as_view()),
+    path('about/', AboutView.as_view(), name="about"),
+    re_path(r'^page/(?:(?P<transcript>[-_\w]+)/)?$', PageView.as_view(), name="view_page"),
+    re_path(r'^page/(?P<start>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', PageView.as_view(), name="view_page"),
+    re_path(r'^(?P<start>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', RangeView.as_view(), name="view_range"),
+    re_path(r'^stream/(?P<start>' + tspatt + ')/?$', transcripts_views.stream, name="stream"),
+    re_path(r'^(?P<start>' + tspatt + ')/(?P<end>' + tspatt + ')/(?:(?P<transcript>[-_\w]+)/)?$', RangeView.as_view(), name="view_range"),
+    path('phases/', PhasesView.as_view(), name="phases"),
+    path('phases/<int:phase_number>/', PhasesView.as_view(), name="phases"),
+    path('search/', SearchView.as_view(), name="search"),
+    path('people/', PeopleView.as_view(), name="people"),
+    re_path(r'^people/(?P<role>[-_\w]+)/$', PeopleView.as_view(), name="people"),
+    path('glossary/', GlossaryView.as_view(), name="glossary"),
+    re_path(r'^original/(?:(?P<transcript>[-_\w]+)/)?(?P<page>-?\d+)/$', OriginalView.as_view(), name="original"),
 ]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
This jumps us all the way from Django 1.11 to Django 5. Everything appears to work, with only minimal usage of deprecation utils for middleware.