### PR TITLE
Allow all features to work in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY backend /src/backend/
 COPY ext /src/ext/
 COPY Makefile /src/
 
+ENV SEARCHDB_PATH /xappydb
 ENV PYTHONIOENCODING utf-8:ignore
 RUN /etc/init.d/redis-server start && \
   make reindex statsporn && \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ global_scss_components    = $(wildcard global/static/css/*/*.scss)
 mission_dirs              = $(subst missions/shared,,$(wildcard missions/*))
 PYTHON                   ?= python3
 SASS                     ?= pyscss
+SEARCHDB_PATH            ?= /xappydb
 
 # Dev Django runserver variables
 dev_webserver_ip         ?= 0.0.0.0
@@ -22,13 +23,15 @@ collectstatic: productioncss statsporn
 	DJANGOENV=live $(PYTHON) -m website.manage collectstatic --noinput --ignore=*.scss
 	DJANGOENV=live $(PYTHON) -m global.manage collectstatic --noinput --ignore=*.scss
 
-reindex: $(indexer)
-	rm -rf xappydb
+reindex: $(SEARCHDB_PATH)
+
+$(SEARCHDB_PATH): missions/*/transcripts/* missions/shared/glossary/* backend/indexer.py
+	rm -rf $(SEARCHDB_PATH)
 	$(PYTHON) -m backend.indexer
 
 statsporn: $(mission_dirs:%=%/images/stats/graph_0.png)
 
-missions/%/images/stats/graph_0.png: missions/%/transcripts/*
+missions/%/images/stats/graph_0.png: missions/%/transcripts/* backend/stats_porn_assets/*  backend/stats_porn.py
 	$(PYTHON) -m backend.stats_porn $*
 
 productioncss:	$(website_css_targets) $(global_css_targets)

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -13,11 +13,9 @@ from django.utils.html import strip_tags
 
 from backend.parser import TranscriptParser, MetaParser
 from backend.api import Act, KeyScene, Character, Glossary, LogLine
-from backend.util import redis_connection, seconds_to_timestamp
+from backend.util import redis_connection, seconds_to_timestamp, get_search_indexer_connection
 
-search_db = xappy.IndexerConnection(
-    os.path.join(os.path.dirname(__file__), '..', 'xappydb'),
-)
+search_db = get_search_indexer_connection()
 
 def mission_time_to_timestamp(mission_time):
     """Takes a mission time string (XX:XX:XX:XX) and converts it to a number of seconds"""

--- a/backend/util.py
+++ b/backend/util.py
@@ -1,6 +1,7 @@
 import math
 import os
 import redis
+import xappy
 
 def seconds_to_timestamp(seconds):
     abss = abs(seconds)
@@ -28,3 +29,14 @@ redis_connection = redis.from_url(
     os.environ.get("REDIS_URL", "redis://localhost:6379"),
     decode_responses=True
 )
+
+searchdb_location = os.getenv(
+    'SEARCHDB_PATH',
+    os.path.join(os.path.dirname(__file__), '..', 'xappydb')
+)
+
+def get_search_indexer_connection(path=searchdb_location):
+    return xappy.IndexerConnection(path)
+
+def get_search_connection(path=searchdb_location):
+    return xappy.SearchConnection(path)

--- a/global/apps/search/views.py
+++ b/global/apps/search/views.py
@@ -4,10 +4,10 @@ from django.views.generic import TemplateView
 from django.urls import reverse
 from django.conf import settings
 from django.utils.safestring import mark_safe
-import xappy
 import xapian
 import redis
 from backend.api import LogLine, Character
+from backend.util import get_search_connection
 
 PAGESIZE = 20
 
@@ -39,13 +39,7 @@ class SearchView(TemplateView):
             }
 
         # Get the results from Xapian
-        db = xappy.SearchConnection(
-            os.path.join(
-                settings.SITE_ROOT,
-                '..',
-                "xappydb",
-            ),
-        )
+        db = get_search_connection()
         query = db.query_parse(
             q,
             default_op=db.OP_OR,

--- a/website/apps/search/views.py
+++ b/website/apps/search/views.py
@@ -4,11 +4,10 @@ from django.views.generic import TemplateView
 from django.urls import reverse
 from django.conf import settings
 from django.utils.safestring import mark_safe
-import xappy
 import xapian
 import redis
 from backend.api import LogLine, Character
-from backend.util import timestamp_to_seconds
+from backend.util import timestamp_to_seconds, get_search_connection
 from common.views import MemorialMixin
 
 PAGESIZE = 20
@@ -43,13 +42,7 @@ class SearchView(MemorialMixin, TemplateView):
             }
 
         # Get the results from Xapian
-        db = xappy.SearchConnection(
-            os.path.join(
-                settings.SITE_ROOT,
-                '..',
-                "xappydb",
-            ),
-        )
+        db = get_search_connection()
         db.set_weighting_scheme(
             xapian.BM25Weight(
                 1, # k1

--- a/website/configs/development/settings.py
+++ b/website/configs/development/settings.py
@@ -10,3 +10,7 @@ try:
     from local_settings import *
 except ImportError:
     pass
+
+STATICFILES_DIRS += [
+    "/home/spacelog/assets/website"
+]


### PR DESCRIPTION
Previously, getting search to work in development meant doing a bunch of bespoke work per environment. And our move to Docker-based development meant that we couldn't display stats graphs unless they were manually built with a mounted working directory after building the container.

This moves our search index out of the working directory and falls back to the pre-built, out-of-working-directory stats graphs, so that both now work as expected in development by default.